### PR TITLE
fix: tighten distribution truth and ci layering

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: Repository overview
-    url: https://github.com/xiaojiou176/apple-notes-forensics
+    url: https://github.com/xiaojiou176-open/apple-notes-forensics
     about: Start with the root README if you are evaluating the project from the outside.
   - name: Security report
-    url: https://github.com/xiaojiou176/apple-notes-forensics/security/advisories/new
+    url: https://github.com/xiaojiou176-open/apple-notes-forensics/security/advisories/new
     about: Use GitHub Security Advisories for private vulnerability reporting.
   - name: Support guide
-    url: https://github.com/xiaojiou176/apple-notes-forensics/blob/main/SUPPORT.md
+    url: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/SUPPORT.md
     about: Read the support guide before opening a public issue.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:00"
       timezone: "America/Los_Angeles"
     cooldown:
@@ -15,8 +14,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:00"
       timezone: "America/Los_Angeles"
     cooldown:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,9 +210,6 @@ jobs:
       - name: Run pre-commit guardrails
         run: pre-commit run --all-files
       - name: Run pre-push guardrails
-        env:
-          GH_TOKEN: ${{ github.token }}
-          NOTESTORELAB_ALLOW_SECRET_SCANNING_FALLBACK: "1"
         run: pre-commit run --all-files --hook-stage pre-push
 
   open-source-boundary:
@@ -227,3 +224,18 @@ jobs:
           python-version: "3.11"
       - name: Check open-source boundary
         run: python scripts/ci/check_repo_hygiene.py --mode open-source-boundary
+
+  distribution-readiness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.11"
+      - name: Install development dependencies
+        run: pip install -e .[dev]
+      - name: Check distribution metadata and build readiness
+        run: python scripts/release/check_pypi_publish_readiness.py

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,8 +7,9 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
   schedule:
-    - cron: "21 7 * * 1"
+    - cron: "21 7 * * *"
 
 permissions:
   actions: read

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -6,6 +6,10 @@ useDefault = true
 [allowlist]
 description = "Ignore local-only support surfaces that are outside the tracked public repo"
 paths = [
+  '''(^|/)\.agents/''',
+  '''(^|/)\.agent/''',
+  '''(^|/)\.codex/''',
+  '''(^|/)\.claude/''',
   '''(^|/)\.venv/''',
   '''(^|/)\.pytest_cache/''',
   '''(^|/)\.runtime-cache/''',

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,14 +86,6 @@ repos:
         language: system
         pass_filenames: false
 
-      - id: pypi-publish-readiness
-        name: PyPI publish readiness pre-push gate
-        entry: python3 scripts/release/check_pypi_publish_readiness.py
-        language: system
-        pass_filenames: false
-        stages:
-          - pre-push
-
       - id: baseline-smoke
         name: baseline smoke pre-push gate
         entry: >
@@ -133,18 +125,6 @@ repos:
       - id: commit-identity-push
         name: commit identity pre-push gate
         entry: python3 scripts/ci/check_commit_identity.py --mode all
-        language: system
-        pass_filenames: false
-        stages:
-          - pre-push
-
-      - id: github-security-alerts-push
-        name: GitHub security alerts pre-push gate
-        entry: >
-          bash -lc 'if [ -z "${GH_TOKEN:-}" ]; then
-            export GH_TOKEN="$(gh auth token 2>/dev/null || true)";
-          fi &&
-          python3 scripts/ci/check_github_security_alerts.py'
         language: system
         pass_filenames: false
         stages:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,10 +164,11 @@ bundles locally:
 ```
 
 If you are touching `server.json` or the MCP Registry story, keep the package
-boundary honest: registry metadata alone is not publish-ready until the
-referenced public package artifact exists in the package registry.
+boundary honest: registry metadata alone is not a live-package claim. Treat the
+package name/version in `server.json` as the intended publication target until
+fresh PyPI read-back says otherwise.
 
-PyPI publish-readiness smoke:
+PyPI metadata/build-readiness smoke:
 
 ```bash
 .venv/bin/python scripts/release/check_pypi_publish_readiness.py
@@ -208,6 +209,21 @@ python3 scripts/ci/check_host_safety_contract.py
 This file is the canonical detailed verification contract. Keep README focused
 on the public front door, and keep the full command-level verification surface
 here.
+
+## CI Layer Map
+
+Use this layer map when you decide where a check belongs:
+
+| Layer | Default trigger | What belongs here |
+| --- | --- | --- |
+| `pre-commit` | every local commit attempt | fast local static gates, hygiene, docs/public-surface drift guards, and host-safety checks |
+| `pre-push` | before pushing a branch | local baseline smoke on the core recovery path, plus commit-history identity checks |
+| `hosted` | GitHub Actions on `push` / `pull_request` | required matrix jobs, repo-hygiene/security scans, optional-surface smoke, and deterministic distribution build-readiness |
+| `nightly` | scheduled GitHub Actions | non-required deep analysis that is useful over time but too heavy or too platform-bound for the default push path |
+| `manual` | maintainer-triggered or owner-side | live GitHub settings/storefront checks, registry/marketplace submission, PyPI publish, and final release-readiness acceptance |
+
+Keep remote GitHub-state checks and publication checks out of the default local
+push path unless they are the specific surface you are actively validating.
 
 Start with the baseline smoke contract:
 
@@ -286,7 +302,7 @@ Distribution bundle smoke:
 .venv/bin/python scripts/release/build_distribution_bundles.py --out-dir ./dist
 ```
 
-PyPI publish-readiness smoke:
+PyPI metadata/build-readiness smoke:
 
 ```bash
 .venv/bin/python scripts/release/check_pypi_publish_readiness.py
@@ -479,7 +495,9 @@ checklist instead of pretending they are repo-side facts:
 
 - Verify that the current Topics list still matches the repository positioning
 - Upload and re-check the custom social preview from the GitHub repository
-  Settings UI after any `assets/social/` change
+  Settings UI after any `assets/social/` change. Treat REST
+  `open_graph_image_url` as the custom-upload signal; the GraphQL
+  `openGraphImageUrl` field can still expose a generated repository card.
 - Confirm that the current release page includes the expected synthetic public
   demo asset before describing it as live
 

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -14,7 +14,7 @@ Use it when you need to answer:
 
 | Surface | Official public surface exists | Repo-owned artifact shipped | Already listed | Current truthful claim |
 | --- | --- | --- | --- | --- |
-| MCP Registry | yes, the official MCP Registry exists and is still documented as a preview surface | yes: `server.json` and `notes-recovery-mcp` | not confirmed | registry metadata draft shipped and points at a live PyPI package; do not claim canonical alignment, submission success, or listing without fresh registry read-back |
+| MCP Registry | yes, the official MCP Registry exists and is still documented as a preview surface | yes: `server.json` and `notes-recovery-mcp` | not confirmed | registry metadata draft shipped; `server.json` records the intended PyPI package identifier/version, but the package is not yet confirmed live on PyPI. Do not claim submission success, listing, or package availability without fresh PyPI and registry read-back |
 | Codex | yes, the official Codex plugin directory exists, but third-party official-directory submission is still coming soon | yes: `plugins/notestorelab-codex-plugin/` | not confirmed | public-ready Codex plugin bundle shipped; do not claim official Codex directory listing |
 | Claude Code | yes, official plugin and marketplace surfaces exist | yes: `plugins/notestorelab-claude-plugin/` plus root `.claude-plugin/marketplace.json` | not confirmed | submit-ready Claude Code marketplace artifact shipped; do not claim Anthropic-managed listing without fresh read-back |
 | OpenClaw | yes, the official ClawHub public registry exists | yes: `plugins/notestorelab-openclaw-bundle/` | not confirmed | public-ready compatible bundle shipped; do not claim live ClawHub or official OpenClaw listing |
@@ -65,15 +65,13 @@ claude plugin validate .
 
 `server.json` is only the metadata side of the MCP Registry story.
 
-The referenced `pypi` package for this repository already exists on PyPI.
+Right now, that file should be treated as a submission draft, not as proof that
+PyPI already serves `apple-notes-forensics`.
 
-That means the remaining boundary is no longer "publish the package first."
-The remaining boundary is external: registry submission, listing, and fresh
-read-back.
-
-The repo-side proof command below is still useful because it checks that the
-metadata continues to point at the expected package surface. Passing it does
-not prove that the MCP Registry has accepted, listed, or rendered the entry.
+The repo-side proof command below checks metadata alignment plus
+build-and-`twine` readiness before an owner-side publish step. Passing it does
+not prove that PyPI, the MCP Registry, or any official directory has accepted,
+listed, or rendered the package.
 
 The repo-side publish-readiness proof command is:
 
@@ -84,7 +82,7 @@ The repo-side publish-readiness proof command is:
 ## Allowed Claims
 
 - "registry metadata draft shipped"
-- "registry metadata points at the live PyPI package"
+- "`server.json` records the intended PyPI package identifier and version"
 - "public-ready Codex plugin bundle shipped"
 - "submit-ready Claude Code marketplace artifact shipped"
 - "OpenClaw-compatible bundle shipped"
@@ -93,6 +91,8 @@ The repo-side publish-readiness proof command is:
 
 - "officially listed" without fresh external read-back
 - "MCP Registry submission completed" without fresh registry read-back
+- "PyPI package already exists" without fresh PyPI read-back
+- "registry metadata points at the live PyPI package" without fresh PyPI read-back
 - "official Codex plugin directory listing" without OpenAI-managed listing proof
 - "official Anthropic marketplace listing" without fresh marketplace read-back
 - "live ClawHub listing" without fresh OpenClaw-side listing proof

--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -136,10 +136,11 @@ Those bundles are repo-owned public-ready artifacts, not official marketplace
 or registry listings.
 
 For MCP Registry publication, `server.json` is still only the metadata layer.
-The referenced public package artifact must exist before this repository can
-truthfully claim MCP Registry publish readiness.
+Treat the package name/version there as the intended publication target, not as
+proof that PyPI already serves it. Use [DISTRIBUTION.md](./DISTRIBUTION.md)
+when you need the current listing or live-package truth.
 
-Repo-side publish-readiness proof:
+Repo-side metadata/build-readiness proof:
 
 ```bash
 .venv/bin/python scripts/release/check_pypi_publish_readiness.py

--- a/README.md
+++ b/README.md
@@ -339,8 +339,9 @@ Those public-ready surfaces live under `plugins/`, `.claude-plugin/`, and
 ```
 
 For the MCP Registry specifically, `server.json` is only the metadata draft.
-The referenced public package artifact must exist before MCP Registry
-publication becomes truthfully submit-ready.
+It records the intended PyPI package identifier/version for a future publish
+step, not proof that PyPI already serves the package. Use
+[DISTRIBUTION.md](./DISTRIBUTION.md) for current listing truth.
 
 When you want the repo-side publish gate before any owner-side PyPI upload, run:
 
@@ -417,7 +418,8 @@ The current live/public sync status is:
 - `llms.txt` is now the fastest AI-crawler / agent-reader entrypoint for the current shipped public contract
 - GitHub description and topics are refreshed to the current AI/MCP story
 - release `v0.1.0` title/body/asset are refreshed
-- custom social preview still requires a GitHub Settings upload/verify step
+- custom social preview still requires a GitHub Settings upload plus REST
+  `open_graph_image_url` read-back before you claim a custom card is live
 
 ## Trust Surface
 
@@ -443,8 +445,9 @@ The root-level public contract for this repository is intentionally narrow:
 
 ### Baseline verification contract
 
-The repository keeps a narrow baseline smoke contract that matches the default
-CI guarantee. The canonical baseline smoke and full suite commands live in
+The repository keeps a narrow baseline smoke contract that matches the hosted
+baseline lane, not the entire CI matrix. The canonical baseline smoke and full
+suite commands live in
 [CONTRIBUTING.md](./CONTRIBUTING.md) so the public front door stays brief while
 the detailed verification contract stays in one place.
 

--- a/plugins/notestorelab-codex-plugin/.codex-plugin/plugin.json
+++ b/plugins/notestorelab-codex-plugin/.codex-plugin/plugin.json
@@ -4,10 +4,10 @@
   "description": "Case-root review workflow and bounded MCP launcher for NoteStore Lab.",
   "author": {
     "name": "NoteStore Lab contributors",
-    "url": "https://github.com/xiaojiou176/apple-notes-forensics"
+    "url": "https://github.com/xiaojiou176-open/apple-notes-forensics"
   },
-  "homepage": "https://github.com/xiaojiou176/apple-notes-forensics",
-  "repository": "https://github.com/xiaojiou176/apple-notes-forensics",
+  "homepage": "https://github.com/xiaojiou176-open/apple-notes-forensics",
+  "repository": "https://github.com/xiaojiou176-open/apple-notes-forensics",
   "license": "MIT",
   "keywords": [
     "apple-notes",
@@ -27,9 +27,9 @@
     "capabilities": [
       "Read"
     ],
-    "websiteURL": "https://github.com/xiaojiou176/apple-notes-forensics",
-    "privacyPolicyURL": "https://github.com/xiaojiou176/apple-notes-forensics/blob/main/SECURITY.md",
-    "termsOfServiceURL": "https://github.com/xiaojiou176/apple-notes-forensics/blob/main/LICENSE",
+    "websiteURL": "https://github.com/xiaojiou176-open/apple-notes-forensics",
+    "privacyPolicyURL": "https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/SECURITY.md",
+    "termsOfServiceURL": "https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/LICENSE",
     "defaultPrompt": [
       "Use NoteStore Lab to inspect the review_index before forming conclusions.",
       "Use NoteStore Lab to answer one bounded question from derived artifacts, not the live Notes store."

--- a/proof.html
+++ b/proof.html
@@ -338,7 +338,7 @@ notes-recovery doctor</code></pre>
           </div>
           <div class="card warm-card">
             <strong>Storefront checks</strong>
-            <p>Custom social preview, release-page assets, and other storefront surfaces still require fresh platform-side read-back.</p>
+            <p>Custom social preview still depends on GitHub Settings upload plus REST <code>open_graph_image_url</code> read-back. A generated repository card URL is not the same thing as a confirmed custom upload.</p>
           </div>
           <div class="card warm-card">
             <strong>Registry and marketplace listings</strong>

--- a/scripts/ci/check_public_story_truth.py
+++ b/scripts/ci/check_public_story_truth.py
@@ -4,9 +4,17 @@ import sys
 from pathlib import Path
 
 try:
-    from scripts.ci.contracts import PUBLIC_STORY_FORBIDDEN_CHANGELOG_TOKENS, README_TAG_RELEASE_URL
+    from scripts.ci.contracts import (
+        PUBLIC_STORY_FORBIDDEN_CHANGELOG_TOKENS,
+        PUBLIC_STORY_FORBIDDEN_DOC_TOKENS,
+        README_TAG_RELEASE_URL,
+    )
 except ModuleNotFoundError:  # pragma: no cover - direct script execution fallback
-    from contracts import PUBLIC_STORY_FORBIDDEN_CHANGELOG_TOKENS, README_TAG_RELEASE_URL
+    from contracts import (
+        PUBLIC_STORY_FORBIDDEN_CHANGELOG_TOKENS,
+        PUBLIC_STORY_FORBIDDEN_DOC_TOKENS,
+        README_TAG_RELEASE_URL,
+    )
 
 TAIL_HANDLER_TAG_RELEASE_URL = README_TAG_RELEASE_URL
 
@@ -16,6 +24,16 @@ def _read(repo_root: Path, rel_path: str) -> str | None:
     if not path.exists():
         return None
     return path.read_text(encoding="utf-8")
+
+
+def _contains_overclaimed_distribution_token(text: str, token: str) -> bool:
+    for line in text.splitlines():
+        if token not in line:
+            continue
+        if "without fresh PyPI read-back" in line:
+            continue
+        return True
+    return False
 
 
 def collect_public_story_truth_errors(repo_root: Path) -> list[str]:
@@ -41,6 +59,14 @@ def collect_public_story_truth_errors(repo_root: Path) -> list[str]:
     for token in PUBLIC_STORY_FORBIDDEN_CHANGELOG_TOKENS:
         if token in changelog_text:
             errors.append(f"CHANGELOG.md contains a stale public-story claim: {token}")
+
+    for rel_path in ("README.md", "DISTRIBUTION.md", "INTEGRATIONS.md"):
+        text = _read(repo_root, rel_path)
+        if text is None:
+            continue
+        for token in PUBLIC_STORY_FORBIDDEN_DOC_TOKENS:
+            if _contains_overclaimed_distribution_token(text, token):
+                errors.append(f"{rel_path} contains an over-claimed distribution token: {token}")
 
     return errors
 

--- a/scripts/ci/check_repo_hygiene.py
+++ b/scripts/ci/check_repo_hygiene.py
@@ -39,7 +39,6 @@ REQUIRED_PRECOMMIT_TOKENS = (
     "actionlint workflow lint",
     "check_commit_identity.py",
     "check_sensitive_surface.py",
-    "check_github_security_alerts.py",
     "check_host_safety_contract.py",
     "check_repo_hygiene.py --mode hygiene",
     "check_repo_hygiene.py --mode open-source-boundary",
@@ -53,6 +52,7 @@ REQUIRED_WORKFLOW_TOKENS = (
     "check_commit_identity.py",
     "check_sensitive_surface.py",
     "check_github_security_alerts.py",
+    "check_pypi_publish_readiness.py",
     "check_host_safety_contract.py",
     "rhysd/actionlint@",
     "trufflehog git",
@@ -64,7 +64,8 @@ REQUIRED_WORKFLOW_TOKENS = (
 REQUIRED_DEPENDABOT_TOKENS = (
     'package-ecosystem: "pip"',
     'package-ecosystem: "github-actions"',
-    'interval: "weekly"',
+    'interval: "daily"',
+    'time: "09:00"',
     'timezone: "America/Los_Angeles"',
 )
 

--- a/scripts/ci/contracts.py
+++ b/scripts/ci/contracts.py
@@ -107,3 +107,8 @@ PUBLIC_STORY_FORBIDDEN_CHANGELOG_TOKENS = (
     "social-preview image",
     "demo GIF",
 )
+
+PUBLIC_STORY_FORBIDDEN_DOC_TOKENS = (
+    "already exists on PyPI",
+    "points at the live PyPI package",
+)

--- a/starter-bundles/codex/plugins/notestorelab/.codex-plugin/plugin.json
+++ b/starter-bundles/codex/plugins/notestorelab/.codex-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "notestorelab",
   "version": "0.1.0",
   "description": "Repo-owned starter plugin for attaching NoteStore Lab's local read-mostly MCP workflow to one copied-evidence workspace.",
-  "homepage": "https://github.com/xiaojiou176/apple-notes-forensics",
-  "repository": "https://github.com/xiaojiou176/apple-notes-forensics",
+  "homepage": "https://github.com/xiaojiou176-open/apple-notes-forensics",
+  "repository": "https://github.com/xiaojiou176-open/apple-notes-forensics",
   "license": "MIT",
   "keywords": [
     "codex",

--- a/tests/test_distribution_bundles.py
+++ b/tests/test_distribution_bundles.py
@@ -25,7 +25,7 @@ def test_distribution_artifacts_exist() -> None:
     assert marketplace_payload["plugins"][0]["name"] == "notestorelab-claude-plugin"
     assert marketplace_payload["plugins"][0]["author"]["email"] == marketplace_payload["owner"]["email"]
     assert marketplace_payload["plugins"][0]["source"] == "./plugins/notestorelab-claude-plugin"
-    assert "already exists on PyPI" in distribution_text
+    assert "intended PyPI package identifier and version" in distribution_text
     assert '"MCP Registry submission completed"' in distribution_text
 
     assert (repo_root / "plugins" / "notestorelab-codex-plugin" / ".codex-plugin" / "plugin.json").exists()

--- a/tests/test_pypi_publish_readiness.py
+++ b/tests/test_pypi_publish_readiness.py
@@ -13,14 +13,16 @@ def test_collect_publish_readiness_errors_passes_for_repo_root() -> None:
     assert errors == []
 
 
-def test_publish_readiness_is_wired_into_guardrails() -> None:
+def test_publish_readiness_is_wired_into_hosted_guardrails() -> None:
     repo_root = Path.cwd()
     precommit_text = (repo_root / ".pre-commit-config.yaml").read_text(encoding="utf-8")
     workflow_text = (repo_root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
 
-    assert "check_pypi_publish_readiness.py" in precommit_text
-    assert "PyPI publish readiness pre-push gate" in precommit_text
-    assert "Run pre-push guardrails" in workflow_text
+    assert "check_pypi_publish_readiness.py" not in precommit_text
+    assert "PyPI publish readiness pre-push gate" not in precommit_text
+    assert "distribution-readiness:" in workflow_text
+    assert "Check distribution metadata and build readiness" in workflow_text
+    assert "check_pypi_publish_readiness.py" in workflow_text
 
 
 def test_module_runner_prefers_repo_venv_fallback(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_repo_surface.py
+++ b/tests/test_repo_surface.py
@@ -151,7 +151,6 @@ def test_repo_hygiene_detects_missing_precommit_tokens(tmp_path: Path) -> None:
     assert any("missing required token: actionlint workflow lint" in error for error in errors)
     assert any("missing required token: check_commit_identity.py" in error for error in errors)
     assert any("missing required token: check_sensitive_surface.py" in error for error in errors)
-    assert any("missing required token: check_github_security_alerts.py" in error for error in errors)
     assert any("missing required token: check_host_safety_contract.py" in error for error in errors)
     assert any("open-source-boundary" in error for error in errors)
     assert any(".env.example is missing required token: NOTES_CASE_PGP_KEY" in error for error in errors)
@@ -409,6 +408,14 @@ def test_public_story_truth_passes_for_truthful_surface(tmp_path: Path) -> None:
         tmp_path / "notes_recovery" / "cli" / "tail_handlers.py",
         'CHANGELOG_URL = "https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/CHANGELOG.md"\n',
     )
+    _write(
+        tmp_path / "DISTRIBUTION.md",
+        "# Distribution\nserver.json records the intended PyPI package identifier and version.\n",
+    )
+    _write(
+        tmp_path / "INTEGRATIONS.md",
+        "# Integrations\nUse DISTRIBUTION.md for current listing truth.\n## Forbidden Claims\n- \"registry metadata points at the live PyPI package\" without fresh PyPI read-back\n",
+    )
 
     assert collect_public_story_truth_errors(tmp_path) == []
 
@@ -441,11 +448,16 @@ def test_public_story_truth_detects_stale_release_and_pages_claims(tmp_path: Pat
         tmp_path / "notes_recovery" / "cli" / "tail_handlers.py",
         'RELEASE_URL = "https://github.com/xiaojiou176-open/apple-notes-forensics/releases/tag/v0.1.0"\n',
     )
+    _write(
+        tmp_path / "DISTRIBUTION.md",
+        "# Distribution\nThe referenced pypi package for this repository already exists on PyPI.\nregistry metadata points at the live PyPI package.\n",
+    )
 
     errors = collect_public_story_truth_errors(tmp_path)
     assert any("tag-specific release URL" in error for error in errors)
     assert any("Pages docs surface are now live" in error for error in errors)
     assert any("Public visual asset set" in error for error in errors)
+    assert any("already exists on PyPI" in error for error in errors)
 
 
 def test_discovery_surface_contract_passes_for_aligned_surface(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- clean up stale canonical repo URLs in issue-template and Codex bundle metadata
- tighten MCP/PyPI distribution wording so repo-owned metadata no longer over-claims live package availability
- rebalance CI layers by slimming local pre-push, moving distribution readiness to hosted CI, switching scheduled lanes away from weekly, and hardening gitleaks against local-only support surfaces

## Verification
- `./.venv/bin/python -m pytest tests/ -q`
- `pre-commit run --all-files`
- `pre-commit run --all-files --hook-stage pre-push`
- `./.venv/bin/python scripts/ci/check_release_readiness.py --strict`
- `./.venv/bin/python scripts/release/check_pypi_publish_readiness.py`
- `curl -sS -o /tmp/notestorelab-pypi.json -w '%{http_code}\n' https://pypi.org/pypi/apple-notes-forensics/json`

## Remaining Manual / Platform Tail
- canonical repo still has forks, which repo-side cleanup cannot retract
- `secret_scanning_non_provider_patterns` and `secret_scanning_validity_checks` remain platform-limited / disabled
- closed unmerged PRs still require human review before claiming full publication cleanup
- custom social preview still needs GitHub Settings upload plus REST `open_graph_image_url` read-back before claiming a custom card