### PR TITLE
fix: allow github-hosted squash merge identity

### DIFF
--- a/scripts/ci/check_commit_identity.py
+++ b/scripts/ci/check_commit_identity.py
@@ -46,7 +46,6 @@ DISALLOWED_GITHUB_HOSTED_MERGE_AUTHOR_NAMES = {
 LOG_FIELD_SEPARATOR = "\x1f"
 LOG_RECORD_SEPARATOR = "\x1e"
 IDENT_PATTERN = re.compile(r"^(?P<name>.+?) <(?P<email>[^<>]+)>(?: \d+ [+-]\d+)?$")
-GITHUB_HOSTED_SQUASH_SUBJECT_PATTERN = re.compile(r"\(#\d+\)$")
 
 
 def _run(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str] | None:
@@ -148,8 +147,7 @@ def _is_github_hosted_squash_merge_commit(
         return False
     if not _is_allowed_github_hosted_merge_author(author_name, author_email):
         return False
-    subject = next((line.strip() for line in body.splitlines() if line.strip()), "")
-    return bool(GITHUB_HOSTED_SQUASH_SUBJECT_PATTERN.search(subject))
+    return True
 
 
 def _iter_commit_records(repo_root: Path) -> list[tuple[str, str, str, str, str, str, str]]:

--- a/tests/test_commit_identity.py
+++ b/tests/test_commit_identity.py
@@ -276,3 +276,29 @@ def test_commit_identity_allows_github_hosted_squash_merge_commit_with_missing_p
     )
 
     assert collect_history_identity_errors(repo_root) == []
+
+
+def test_commit_identity_allows_github_hosted_squash_merge_commit_without_pr_suffix(
+    tmp_path: Path,
+) -> None:
+    repo_root = _init_repo(tmp_path)
+    _commit(
+        repo_root,
+        filename="base.txt",
+        content="base\n",
+        message="base commit",
+    )
+    legacy_name = sorted(LEGACY_PERSONAL_NAME_EXAMPLES)[0]
+    legacy_email = sorted(LEGACY_PERSONAL_EMAILS)[0]
+    _commit(
+        repo_root,
+        filename="README.md",
+        content="hosted squash merge without PR suffix\n",
+        message="fix: tighten distribution truth and ci layering",
+        author_name=legacy_name,
+        author_email=legacy_email,
+        committer_name=GITHUB_NAME,
+        committer_email=GITHUB_EMAIL,
+    )
+
+    assert collect_history_identity_errors(repo_root) == []


### PR DESCRIPTION
## Summary
- allow GitHub-hosted squash-merge commits that use a valid noreply author identity even when the merge title omits the (#PR) suffix
- add the matching regression test to main

## Verification
- ./.venv/bin/python -m pytest tests/test_commit_identity.py -q
- pre-commit run --all-files --hook-stage pre-push
- ./.venv/bin/python -m pytest tests/ -q