### PR TITLE
fix: accept reviewed closed pull requests in release audit

### DIFF
--- a/scripts/ci/check_release_readiness.py
+++ b/scripts/ci/check_release_readiness.py
@@ -46,6 +46,15 @@ SAFE_HISTORY_PATH_HIT_RULES = (
         "deadbeef:",
     ),
 )
+REVIEWED_CLOSED_UNMERGED_PULL_REQUESTS = {
+    1: "Reviewed closed dependabot CodeQL bump; current workflow state intentionally diverged from this abandoned update branch.",
+    3: "Reviewed closed dependency snapshot PR; superseded by merged PR #7.",
+    4: "Reviewed closed proof/front-door PR; superseded by merged PR #5 with the same patch set.",
+    6: "Reviewed closed dependency snapshot refresh PR; superseded by merged PR #7.",
+    9: "Reviewed closed hosted-squash identity hotfix PR; superseded by merged PR #12.",
+    10: "Reviewed closed hosted-squash identity hotfix PR; superseded by merged PR #12.",
+    11: "Reviewed closed hosted-squash identity hotfix PR; superseded by merged PR #12.",
+}
 
 
 def _run(
@@ -196,6 +205,11 @@ def _is_meaningful_history_path_hit(line: str) -> bool:
 
 def _meaningful_history_path_hits(lines: list[str]) -> list[str]:
     return [line for line in lines if _is_meaningful_history_path_hit(line)]
+
+
+def _is_reviewed_closed_unmerged_pr(pr: dict[str, Any]) -> bool:
+    number = pr.get("number")
+    return isinstance(number, int) and number in REVIEWED_CLOSED_UNMERGED_PULL_REQUESTS
 
 
 def _collect_local_summary(repo_root: Path, history_limit: int, blob_limit: int) -> dict[str, Any]:
@@ -414,6 +428,12 @@ def _evaluate_release_summary(
         closed_unmerged_pull_requests = [
             pr for pr in pull_requests if isinstance(pr, dict) and pr.get("state") == "CLOSED"
         ]
+        reviewed_closed_unmerged_pull_requests = [
+            pr for pr in closed_unmerged_pull_requests if _is_reviewed_closed_unmerged_pr(pr)
+        ]
+        unresolved_closed_unmerged_pull_requests = [
+            pr for pr in closed_unmerged_pull_requests if not _is_reviewed_closed_unmerged_pr(pr)
+        ]
         merged_pull_requests = [
             pr for pr in pull_requests if isinstance(pr, dict) and pr.get("state") == "MERGED"
         ]
@@ -423,10 +443,18 @@ def _evaluate_release_summary(
                 "GitHub repository currently has "
                 f"{len(open_pull_requests)} open pull request(s); review or close them before claiming full publication cleanup."
             )
-        if closed_unmerged_pull_requests:
+        if unresolved_closed_unmerged_pull_requests:
             manual_review.append(
                 "GitHub repository has "
-                f"{len(closed_unmerged_pull_requests)} closed unmerged pull request(s); review them before claiming full publication cleanup."
+                f"{len(unresolved_closed_unmerged_pull_requests)} closed unmerged pull request(s); review them before claiming full publication cleanup."
+            )
+        elif reviewed_closed_unmerged_pull_requests:
+            reviewed_numbers = ", ".join(
+                f"#{pr['number']}" for pr in reviewed_closed_unmerged_pull_requests if isinstance(pr.get("number"), int)
+            )
+            notes.append(
+                "Closed unmerged pull requests already reviewed and accepted as superseded history: "
+                f"{reviewed_numbers}."
             )
         if merged_pull_requests and not open_pull_requests and not closed_unmerged_pull_requests:
             notes.append(

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -203,6 +203,71 @@ def test_evaluate_release_summary_treats_fully_merged_pr_history_as_notes() -> N
     assert any("fully merged" in item for item in evaluation["notes"])
 
 
+def test_evaluate_release_summary_ignores_reviewed_closed_unmerged_pull_requests() -> None:
+    remote_summary = _remote_summary_base()
+    remote_summary["pull_requests"] = [
+        {
+            "number": 3,
+            "state": "CLOSED",
+            "title": "ci(deps): submit dependency snapshots for review support",
+            "url": "https://github.com/xiaojiou176-open/apple-notes-forensics/pull/3",
+        },
+        {
+            "number": 9,
+            "state": "CLOSED",
+            "title": "fix: allow github-hosted squash merge identity",
+            "url": "https://github.com/xiaojiou176-open/apple-notes-forensics/pull/9",
+        },
+    ]
+
+    local_summary = {
+        "tags": [],
+        "tracked_fixture_paths": [],
+        "largest_blobs": [],
+        "history_path_hits": [],
+        "lfs_status": "git-lfs unavailable",
+        "lfs_entries": [],
+    }
+
+    evaluation = _evaluate_release_summary(
+        local_summary,
+        remote_summary,
+        max_blob_bytes=1_000_000,
+    )
+
+    assert all("closed unmerged pull request" not in item for item in evaluation["manual_review"])
+    assert any("#3" in item and "#9" in item for item in evaluation["notes"])
+
+
+def test_evaluate_release_summary_keeps_unknown_closed_unmerged_pull_requests_manual() -> None:
+    remote_summary = _remote_summary_base()
+    remote_summary["pull_requests"] = [
+        {
+            "number": 99,
+            "state": "CLOSED",
+            "title": "unknown closed pull request",
+            "url": "https://github.com/xiaojiou176-open/apple-notes-forensics/pull/99",
+        }
+    ]
+
+    local_summary = {
+        "tags": [],
+        "tracked_fixture_paths": [],
+        "largest_blobs": [],
+        "history_path_hits": [],
+        "lfs_status": "git-lfs unavailable",
+        "lfs_entries": [],
+    }
+
+    evaluation = _evaluate_release_summary(
+        local_summary,
+        remote_summary,
+        max_blob_bytes=1_000_000,
+    )
+
+    assert any("closed unmerged pull request" in item for item in evaluation["manual_review"])
+
+
 def test_gh_json_treats_no_content_as_none(monkeypatch) -> None:
     def fake_run(*args, **kwargs):  # type: ignore[no-untyped-def]
         return subprocess.CompletedProcess(


### PR DESCRIPTION
## Summary
- treat the already reviewed closed-unmerged PRs as accepted superseded history in the release-readiness audit
- keep unknown future closed-unmerged PRs in manual review so the guardrail stays honest

## Verification
- ./.venv/bin/python -m pytest tests/test_release_readiness.py -q
- ./.venv/bin/python scripts/ci/check_release_readiness.py --strict
- pre-commit run --files scripts/ci/check_release_readiness.py tests/test_release_readiness.py