### PR TITLE
[codex] publish live PyPI package truth

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,14 +164,22 @@ bundles locally:
 ```
 
 If you are touching `server.json` or the MCP Registry story, keep the package
-boundary honest: registry metadata alone is not a live-package claim. Treat the
-package name/version in `server.json` as the intended publication target until
-fresh PyPI read-back says otherwise.
+boundary honest: registry metadata alone is not an MCP Registry listing claim.
+Fresh PyPI read-back now confirms a live package at
+`apple-notes-forensics==0.1.0.post1`, so keep the package name/version in
+`server.json` aligned with the live PyPI package until the next deliberate
+version bump.
 
 PyPI metadata/build-readiness smoke:
 
 ```bash
 .venv/bin/python scripts/release/check_pypi_publish_readiness.py
+```
+
+Fresh PyPI install smoke:
+
+```bash
+python -m pip install apple-notes-forensics==0.1.0.post1
 ```
 
 Independent skill publish-readiness smoke:

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -14,7 +14,7 @@ Use it when you need to answer:
 
 | Surface | Official public surface exists | Repo-owned artifact shipped | Already listed | Current truthful claim |
 | --- | --- | --- | --- | --- |
-| MCP Registry | yes, the official MCP Registry exists and is still documented as a preview surface | yes: `server.json` and `notes-recovery-mcp` | not confirmed | registry metadata draft shipped; `server.json` records the intended PyPI package identifier/version, but the package is not yet confirmed live on PyPI. Do not claim submission success, listing, or package availability without fresh PyPI and registry read-back |
+| MCP Registry | yes, the official MCP Registry exists and is still documented as a preview surface | yes: `server.json` and `notes-recovery-mcp` | not confirmed | live PyPI package now exists at `apple-notes-forensics==0.1.0.post1`, with fresh JSON read-back and install smoke; `server.json` now points at that live package, but MCP Registry listing itself is still not confirmed without fresh registry read-back |
 | Codex | yes, the official Codex plugin directory exists, but third-party official-directory submission is still coming soon | yes: `plugins/notestorelab-codex-plugin/` | not confirmed | public-ready Codex plugin bundle shipped; do not claim official Codex directory listing |
 | Claude Code | yes, official plugin and marketplace surfaces exist | yes: `plugins/notestorelab-claude-plugin/` plus root `.claude-plugin/marketplace.json` | not confirmed | submit-ready Claude Code marketplace artifact shipped; do not claim Anthropic-managed listing without fresh read-back |
 | OpenClaw | yes, the official ClawHub public registry exists | yes: `plugins/notestorelab-openclaw-bundle/` | not confirmed | public-ready compatible bundle shipped; do not claim live ClawHub or official OpenClaw listing |
@@ -92,15 +92,13 @@ claude plugin validate .
 
 ### MCP Registry listing boundary
 
-`server.json` is only the metadata side of the MCP Registry story.
+`server.json` is still only the metadata side of the MCP Registry story.
 
-Right now, that file should be treated as a submission draft, not as proof that
-PyPI already serves `apple-notes-forensics`.
-
-The repo-side proof command below checks metadata alignment plus
-build-and-`twine` readiness before an owner-side publish step. Passing it does
-not prove that PyPI, the MCP Registry, or any official directory has accepted,
-listed, or rendered the package.
+Fresh PyPI read-back now confirms that PyPI serves
+`apple-notes-forensics==0.1.0.post1`, and fresh install smoke confirms that the
+published package is installable. That does **not** prove that the MCP
+Registry, or any other official directory, has accepted, listed, or rendered
+the package.
 
 The repo-side publish-readiness proof command is:
 
@@ -110,8 +108,8 @@ The repo-side publish-readiness proof command is:
 
 ## Allowed Claims
 
-- "registry metadata draft shipped"
-- "`server.json` records the intended PyPI package identifier and version"
+- "live PyPI package `apple-notes-forensics==0.1.0.post1` verified with fresh JSON read-back"
+- "`server.json` points at the live PyPI package `apple-notes-forensics==0.1.0.post1`"
 - "public-ready Codex plugin bundle shipped"
 - "submit-ready Claude Code marketplace artifact shipped"
 - "OpenClaw-compatible bundle shipped"
@@ -122,8 +120,7 @@ The repo-side publish-readiness proof command is:
 
 - "officially listed" without fresh external read-back
 - "MCP Registry submission completed" without fresh registry read-back
-- "PyPI package already exists" without fresh PyPI read-back
-- "registry metadata points at the live PyPI package" without fresh PyPI read-back
+- "registry metadata proves MCP Registry listing" without fresh registry read-back
 - "official Codex plugin directory listing" without OpenAI-managed listing proof
 - "official Anthropic marketplace listing" without fresh marketplace read-back
 - "live ClawHub listing" without fresh OpenClaw-side listing proof

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -14,7 +14,7 @@ Use it when you need to answer:
 
 | Surface | Official public surface exists | Repo-owned artifact shipped | Already listed | Current truthful claim |
 | --- | --- | --- | --- | --- |
-| MCP Registry | yes, the official MCP Registry exists and is still documented as a preview surface | yes: `server.json` and `notes-recovery-mcp` | not confirmed | live PyPI package now exists at `apple-notes-forensics==0.1.0.post1`, with fresh JSON read-back and install smoke; `server.json` now points at that live package, but MCP Registry listing itself is still not confirmed without fresh registry read-back |
+| MCP Registry | yes, the official MCP Registry exists and is still documented as a preview surface | yes: `server.json` and `notes-recovery-mcp` | not confirmed | live PyPI package now exists at `apple-notes-forensics==0.1.0.post1`, with fresh JSON read-back and install smoke; `server.json` is aligned with that live package version, but MCP Registry listing itself is still not confirmed without fresh registry read-back |
 | Codex | yes, the official Codex plugin directory exists, but third-party official-directory submission is still coming soon | yes: `plugins/notestorelab-codex-plugin/` | not confirmed | public-ready Codex plugin bundle shipped; do not claim official Codex directory listing |
 | Claude Code | yes, official plugin and marketplace surfaces exist | yes: `plugins/notestorelab-claude-plugin/` plus root `.claude-plugin/marketplace.json` | not confirmed | submit-ready Claude Code marketplace artifact shipped; do not claim Anthropic-managed listing without fresh read-back |
 | OpenClaw | yes, the official ClawHub public registry exists | yes: `plugins/notestorelab-openclaw-bundle/` | not confirmed | public-ready compatible bundle shipped; do not claim live ClawHub or official OpenClaw listing |
@@ -109,7 +109,7 @@ The repo-side publish-readiness proof command is:
 ## Allowed Claims
 
 - "live PyPI package `apple-notes-forensics==0.1.0.post1` verified with fresh JSON read-back"
-- "`server.json` points at the live PyPI package `apple-notes-forensics==0.1.0.post1`"
+- "`server.json` is aligned with the live PyPI version `0.1.0.post1`"
 - "public-ready Codex plugin bundle shipped"
 - "submit-ready Claude Code marketplace artifact shipped"
 - "OpenClaw-compatible bundle shipped"

--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -136,9 +136,16 @@ Those bundles are repo-owned public-ready artifacts, not official marketplace
 or registry listings.
 
 For MCP Registry publication, `server.json` is still only the metadata layer.
-Treat the package name/version there as the intended publication target, not as
-proof that PyPI already serves it. Use [DISTRIBUTION.md](./DISTRIBUTION.md)
-when you need the current listing or live-package truth.
+Fresh PyPI read-back now confirms a live package at
+`apple-notes-forensics==0.1.0.post1`, but that does **not** prove an MCP
+Registry listing by itself. Use [DISTRIBUTION.md](./DISTRIBUTION.md) when you
+need the current listing or live-package truth.
+
+Fresh PyPI install path:
+
+```bash
+python -m pip install apple-notes-forensics==0.1.0.post1
+```
 
 Repo-side metadata/build-readiness proof:
 

--- a/README.md
+++ b/README.md
@@ -338,10 +338,18 @@ Those public-ready surfaces live under `plugins/`, `.claude-plugin/`, and
 .venv/bin/python scripts/release/build_distribution_bundles.py --out-dir ./dist
 ```
 
-For the MCP Registry specifically, `server.json` is only the metadata draft.
-It records the intended PyPI package identifier/version for a future publish
-step, not proof that PyPI already serves the package. Use
-[DISTRIBUTION.md](./DISTRIBUTION.md) for current listing truth.
+For the MCP Registry specifically, `server.json` is still only the metadata
+layer. Fresh PyPI read-back now confirms a live package at
+`apple-notes-forensics==0.1.0.post1`, and fresh install smoke confirms that
+the published package is installable now. That does **not** by itself prove an
+MCP Registry listing; use [DISTRIBUTION.md](./DISTRIBUTION.md) for the current
+listing boundary.
+
+When you want the live package directly from PyPI, install:
+
+```bash
+python -m pip install apple-notes-forensics==0.1.0.post1
+```
 
 The repository now also ships a canonical independent skill surface at
 `skills/notestorelab-case-review/`. Treat that directory as the SSOT skill
@@ -349,7 +357,8 @@ package, and treat the plugin/starter skill files as host-specific derived
 copies. That makes the skill independently referenceable without pretending it
 is already officially listed anywhere.
 
-When you want the repo-side publish gate before any owner-side PyPI upload, run:
+When you want the repo-side metadata/build-readiness gate before the next PyPI
+version bump, run:
 
 ```bash
 .venv/bin/python scripts/release/check_pypi_publish_readiness.py

--- a/llms.txt
+++ b/llms.txt
@@ -7,6 +7,7 @@
 - Landing: https://xiaojiou176-open.github.io/apple-notes-forensics/
 - Repository: https://github.com/xiaojiou176-open/apple-notes-forensics
 - Releases: https://github.com/xiaojiou176-open/apple-notes-forensics/releases
+- PyPI: https://pypi.org/project/apple-notes-forensics/
 
 ## Start Here
 
@@ -61,7 +62,7 @@
 
 - Codex and Claude Code are both good current examples of hosts that fit the shipped local stdio MCP surface here.
 - Keep the same local stdio command as the source of truth even when each host wraps it differently.
-- INTEGRATIONS.md still includes the minimal `.mcp.json` wrapper example, and `DISTRIBUTION.md` now tracks the shipped plugin bundles, marketplace manifest, and MCP registry metadata draft.
+- INTEGRATIONS.md still includes the minimal `.mcp.json` wrapper example, and `DISTRIBUTION.md` now tracks the live PyPI package read-back, shipped plugin bundles, marketplace manifest, and MCP Registry boundary.
 - The tracked Codex bundle includes `.codex-plugin/plugin.json`, a local marketplace example, and the bundled MCP launcher under `plugins/notestorelab-codex-plugin/`.
 - When you need the literal project config token, the tracked Codex example still maps to `.codex/config.toml` through the bundle layout.
 - Treat remote-connector-first hosts as comparison paths here because this repo does not ship a hosted or remote MCP deployment.

--- a/notes_recovery/mcp/server.py
+++ b/notes_recovery/mcp/server.py
@@ -44,13 +44,20 @@ from notes_recovery.services.report import generate_report
 from notes_recovery.services.timeline import build_timeline
 from notes_recovery.services.verify import verify_hits
 
-try:
-    from mcp.server.fastmcp import FastMCP
-    from mcp.types import ToolAnnotations
-except ModuleNotFoundError as exc:  # pragma: no cover - exercised in runtime usage
-    raise SystemExit(
-        "The MCP server requires the optional MCP dependencies. Install `python -m pip install -e .[mcp]` first."
-    ) from exc
+MCP_DEPENDENCY_HELP = (
+    "The MCP server requires the optional MCP dependencies. "
+    "Install `python -m pip install 'apple-notes-forensics[mcp]'` "
+    "or `python -m pip install -e .[mcp]` first."
+)
+
+
+def _load_mcp_runtime():
+    try:
+        from mcp.server.fastmcp import FastMCP
+        from mcp.types import ToolAnnotations
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised in runtime usage
+        raise SystemExit(MCP_DEPENDENCY_HELP) from exc
+    return FastMCP, ToolAnnotations
 
 
 def _quiet_logging(*_args: Any, **_kwargs: Any) -> None:
@@ -264,6 +271,7 @@ def build_mcp_server(
     case_dirs: Iterable[Path],
     cases_roots: Iterable[Path],
 ) -> FastMCP:
+    FastMCP, ToolAnnotations = _load_mcp_runtime()
     registry = CaseRegistry.build(case_dirs, cases_roots)
     retrieval_contract = derived_artifact_retrieval_contract()
     server = FastMCP(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apple-notes-forensics"
-version = "0.1.0"
+version = "0.1.0.post1"
 description = "Copy-first Apple Notes recovery toolkit for macOS, with reviewable case outputs, AI-assisted review, verification, and public-safe demo artifacts."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/xiaojiou176-open/apple-notes-forensics",
     "source": "github"
   },
-  "version": "0.1.0",
+  "version": "0.1.0.post1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "apple-notes-forensics",
-      "version": "0.1.0",
+      "version": "0.1.0.post1",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5,8 +5,11 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
 from mcp import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
+
+from notes_recovery.mcp import server as mcp_server
 
 
 def _write(path: Path, text: str) -> None:
@@ -29,6 +32,33 @@ def _build_case_root(tmp_path: Path) -> Path:
 def _json_from_tool(result) -> dict:
     assert result.content
     return json.loads(result.content[0].text)
+
+
+def test_mcp_help_does_not_require_optional_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_if_called():
+        raise AssertionError("optional MCP runtime should not be loaded for --help")
+
+    monkeypatch.setattr(mcp_server, "_load_mcp_runtime", fail_if_called)
+
+    with pytest.raises(SystemExit) as exc:
+        mcp_server.main(["--help"])
+
+    assert exc.value.code == 0
+
+
+def test_mcp_runtime_emits_install_hint_when_dependency_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def raise_missing():
+        raise SystemExit(mcp_server.MCP_DEPENDENCY_HELP)
+
+    monkeypatch.setattr(mcp_server, "_load_mcp_runtime", raise_missing)
+
+    with pytest.raises(SystemExit) as exc:
+        mcp_server.main(["--case-dir", str(tmp_path)])
+
+    assert str(exc.value) == mcp_server.MCP_DEPENDENCY_HELP
 
 
 def test_mcp_server_lists_resources_and_runs_verify(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- publish `apple-notes-forensics==0.1.0.post1` to PyPI and align `pyproject.toml` / `server.json`
- fix the base-install `notes-recovery-mcp --help` blocker by deferring optional MCP runtime loading
- sync README / DISTRIBUTION / INTEGRATIONS / CONTRIBUTING / llms.txt to the live PyPI truth without overstating registry listing status

## Test Plan
- [x] `./.venv/bin/python -m pytest tests/test_pypi_publish_readiness.py tests/test_mcp_server.py tests/test_cli_entrypoints.py -q`
- [x] `./.venv/bin/python scripts/release/check_pypi_publish_readiness.py --metadata-only`
- [x] `./.venv/bin/python -m twine upload --non-interactive --verbose .runtime-cache/pypi-release/2026-04-07T0003/apple_notes_forensics-0.1.0.post1.tar.gz .runtime-cache/pypi-release/2026-04-07T0003/apple_notes_forensics-0.1.0.post1-py3-none-any.whl`
- [x] `curl https://pypi.org/pypi/apple-notes-forensics/json`
- [x] fresh venv `python -m pip install apple-notes-forensics==0.1.0.post1`
- [x] fresh venv `notes-recovery --help`
- [x] fresh venv `notes-recovery-mcp --help`

## Breaking Changes
None

## Rollout / Risk
- **风险等级**: Medium
- **灰度策略**: direct publish already completed on PyPI
- **回滚方案**: release a superseding PyPI version if follow-up fixes are needed; do not attempt filename reuse
- **监控指标**: PyPI JSON endpoint, PyPI installability, CLI/MCP help smoke

## Observability
- **新增日志**: None
- **新增指标**: None
- **告警变更**: None

## Checklist
- [x] Self-reviewed code
- [x] No debug/print statements left
- [x] No TODO without issue reference
- [x] Documentation updated (if needed)
- [x] Tests added/updated

## Related Issues
None
