### PR TITLE
fix: finish distribution truth sync and support cleanup lane

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "notestorelab-claude-plugin",
       "description": "Bounded case-root MCP launcher for NoteStore Lab review workflows.",
-      "version": "0.1.0",
+      "version": "0.1.0.post1",
       "author": {
         "name": "NoteStore Lab",
         "email": "xiaojiou176@users.noreply.github.com"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -386,6 +386,31 @@ Do not treat copied Notes evidence, case-root outputs, or public-safe export
 bundles as runtime-cleanup targets. Runtime hygiene here only applies to
 rebuildable local support surfaces.
 
+For repo-owned release/rewrite support residue under `.runtime-cache/`, use the
+maintainer-only cleanup helper:
+
+```bash
+python scripts/ops/clean_support_state.py --dry-run
+python scripts/ops/clean_support_state.py --apply
+```
+
+That helper is intentionally narrow. It may remove:
+
+- `.runtime-cache/pypi-release`
+- `.runtime-cache/history-rewrite-*`
+- `.runtime-cache/release`
+- `.runtime-cache/pypi-publish-attempt-*`
+- `.runtime-cache/lighthouse-pages*`
+- `.runtime-cache/security-audit`
+- `.runtime-cache/temp`
+- `.runtime-cache/dist-bundles`
+- `.runtime-cache/*starter*.zip`
+- `.runtime-cache/verify-*`
+- `.runtime-cache/gitleaks-*.json`
+
+It does **not** touch copied evidence, `output/`, Docker state, browser
+profiles, or shared machine caches.
+
 For deeper changes, run the broader full suite engineering sweep:
 
 ```bash

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -54,6 +54,25 @@ This means the repository can now truthfully say "independent skill surface
 shipped" or "independent skill ready" without claiming any official directory
 listing.
 
+## Package Surface
+
+The canonical installable package surface for this repository is PyPI:
+
+- package name: `apple-notes-forensics`
+- live package truth comes from PyPI JSON read-back plus install smoke
+- `server.json` points at the PyPI package because the current MCP publication
+  story is Python-first
+
+There is no tracked npm package surface in the current public contract:
+
+- no `package.json`
+- no npm install path in the public docs
+- no shipped TypeScript SDK or generated client surface yet
+
+That means npm is not a missing canonical package lane for this repository
+today. If a future npm surface ever ships, it must become an explicit new
+public contract rather than an implied comparison path.
+
 ## Container Surface
 
 Docker-ready local container surface shipped:
@@ -65,6 +84,14 @@ Docker-ready local container surface shipped:
 This container path is for local reproducibility of the CLI and stdio MCP
 surface. It is not proof of a hosted deployment, multi-tenant backend, or live
 Glama listing.
+
+The canonical live-image target, if and when fresh publish proof exists, is:
+
+- `ghcr.io/xiaojiou176-open/apple-notes-forensics:0.1.0.post1`
+- optional convenience tag: `ghcr.io/xiaojiou176-open/apple-notes-forensics:latest`
+
+Do not claim a live OCI image without fresh GHCR push read-back and pull/read
+verification.
 
 ## Proof Loops
 
@@ -110,11 +137,13 @@ The repo-side publish-readiness proof command is:
 
 - "live PyPI package `apple-notes-forensics==0.1.0.post1` verified with fresh JSON read-back"
 - "`server.json` is aligned with the live PyPI version `0.1.0.post1`"
+- "PyPI is the canonical installable package surface for this repository today"
 - "public-ready Codex plugin bundle shipped"
 - "submit-ready Claude Code marketplace artifact shipped"
 - "OpenClaw-compatible bundle shipped"
 - "independent skill surface shipped"
 - "Docker-ready local container surface shipped"
+- "`ghcr.io/xiaojiou176-open/apple-notes-forensics` is the canonical live-image target, but live-image claims still require fresh GHCR push and pull read-back"
 
 ## Forbidden Claims
 
@@ -124,5 +153,6 @@ The repo-side publish-readiness proof command is:
 - "official Codex plugin directory listing" without OpenAI-managed listing proof
 - "official Anthropic marketplace listing" without fresh marketplace read-back
 - "live ClawHub listing" without fresh OpenClaw-side listing proof
+- "official npm package" or "npm is the canonical install path" without a real shipped npm package surface
 - "officially listed skill" without fresh host-side read-back
 - "hosted service" or "multi-tenant platform" for the Docker surface

--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -188,13 +188,13 @@ The truthful container story for this repository is:
 Canonical build:
 
 ```bash
-docker build -t notestorelab:0.1.0 .
+docker build -t notestorelab:0.1.0.post1 .
 ```
 
 Public-safe demo smoke:
 
 ```bash
-docker run --rm notestorelab:0.1.0 notes-recovery demo
+docker run --rm notestorelab:0.1.0.post1 notes-recovery demo
 ```
 
 Bounded MCP entrypoint:
@@ -203,9 +203,14 @@ Bounded MCP entrypoint:
 docker run --rm -i \
   -v "$PWD/output:/cases:ro" \
   --entrypoint notes-recovery-mcp \
-  notestorelab:0.1.0 \
+  notestorelab:0.1.0.post1 \
   --case-dir /cases/Notes_Forensics_<run_ts>
 ```
+
+If you need a canonical live-image target later, use
+`ghcr.io/xiaojiou176-open/apple-notes-forensics:0.1.0.post1`, and treat
+`latest` as a convenience tag rather than the sole source of truth. Do not
+describe that image as live until fresh GHCR push and pull read-back exist.
 
 `docker-compose` is intentionally absent here. This repo is a local CLI / MCP
 workbench, not a multi-service stack. The container image is the repo-side

--- a/README.md
+++ b/README.md
@@ -402,19 +402,19 @@ The Docker story is intentionally narrow:
 Build the image:
 
 ```bash
-docker build -t notestorelab:0.1.0 .
+docker build -t notestorelab:0.1.0.post1 .
 ```
 
 Run the public-safe demo:
 
 ```bash
-docker run --rm notestorelab:0.1.0 notes-recovery demo
+docker run --rm notestorelab:0.1.0.post1 notes-recovery demo
 ```
 
 Run the MCP help surface:
 
 ```bash
-docker run --rm --entrypoint notes-recovery-mcp notestorelab:0.1.0 --help
+docker run --rm --entrypoint notes-recovery-mcp notestorelab:0.1.0.post1 --help
 ```
 
 Review an existing copied case root through the local stdio MCP server:
@@ -423,9 +423,14 @@ Review an existing copied case root through the local stdio MCP server:
 docker run --rm -i \
   -v "$PWD/output:/cases:ro" \
   --entrypoint notes-recovery-mcp \
-  notestorelab:0.1.0 \
+  notestorelab:0.1.0.post1 \
   --case-dir /cases/Notes_Forensics_<run_ts>
 ```
+
+If you later publish a registry image, the canonical target is
+`ghcr.io/xiaojiou176-open/apple-notes-forensics:0.1.0.post1`, with `latest`
+as an optional convenience tag only after matching read-back. Do not claim a
+live registry image until fresh push and pull verification both succeed.
 
 The container image is a reproducible local runtime, not a hosted portal, not
 an API gateway, and not proof of any live Glama or OCI catalog listing.
@@ -435,6 +440,35 @@ ecosystem binding matrix in [ECOSYSTEM.md](./ECOSYSTEM.md) before you describe
 the repo as an integration substrate. Use [DISTRIBUTION.md](./DISTRIBUTION.md)
 when you need the exact claim boundary for Codex, Claude Code, OpenClaw, and
 the MCP Registry.
+
+## Repo-native support cleanup
+
+This repository now ships a small repo-native cleanup lane for local release and
+rewrite residue. Use it when you want to reclaim repo-local staging artifacts
+without touching copied evidence, `output/`, Docker state, browser profiles, or
+shared machine caches.
+
+```bash
+python scripts/ops/clean_support_state.py --dry-run
+python scripts/ops/clean_support_state.py --apply
+```
+
+Current cleanup classes include:
+
+- `.runtime-cache/pypi-release`
+- `.runtime-cache/history-rewrite-*`
+- `.runtime-cache/release`
+- `.runtime-cache/pypi-publish-attempt-*`
+- `.runtime-cache/lighthouse-pages*`
+- `.runtime-cache/security-audit`
+- `.runtime-cache/temp`
+- `.runtime-cache/dist-bundles`
+- `.runtime-cache/*starter*.zip`
+- `.runtime-cache/verify-*`
+- `.runtime-cache/gitleaks-*.json`
+
+Treat this as a maintainer-only lane. It is for support residue, not for copied
+evidence or public proof assets.
 
 ## Plugin Contract And Case Diff
 

--- a/plugins/notestorelab-codex-plugin/.codex-plugin/plugin.json
+++ b/plugins/notestorelab-codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "notestorelab-codex-plugin",
-  "version": "0.1.0",
+  "version": "0.1.0.post1",
   "description": "Case-root review workflow and bounded MCP launcher for NoteStore Lab.",
   "author": {
     "name": "NoteStore Lab contributors",

--- a/scripts/ops/clean_support_state.py
+++ b/scripts/ops/clean_support_state.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+
+TARGET_SPECS = [
+    ("pypi-release", ".runtime-cache/pypi-release", "rerun the PyPI release preparation path"),
+    ("history-rewrite-rollback", ".runtime-cache/history-rewrite-*", "only keep rewrite rollback artifacts while you still need rollback evidence"),
+    ("release-staging", ".runtime-cache/release", "rerun the release packaging workflow"),
+    ("publish-attempt", ".runtime-cache/pypi-publish-attempt-*", "rerun the PyPI publish attempt after credentials are ready"),
+    ("pages-audit", ".runtime-cache/lighthouse-pages*", "rerun the Pages / landing verification workflow"),
+    ("security-audit", ".runtime-cache/security-audit", "rerun the repo-side security audit workflow"),
+    ("support-temp", ".runtime-cache/temp", "rerun the documented support workflow"),
+    ("bundle-staging", ".runtime-cache/dist-bundles", "rerun the bundle build workflow"),
+    ("bundle-archive", ".runtime-cache/*starter*.zip", "rerun starter bundle export if you still need archived copies"),
+    ("verification-temp", ".runtime-cache/verify-*", "rerun the matching verify command if you still need a fresh temp capture"),
+    ("scanner-ledger", ".runtime-cache/gitleaks-*.json", "rerun the gitleaks scan if you still need a fresh JSON ledger"),
+]
+
+
+def repo_root() -> Path:
+    return Path.cwd().resolve()
+
+
+def match_targets(root: Path) -> list[tuple[str, Path, str]]:
+    matches: list[tuple[str, Path, str]] = []
+    for class_name, pattern, rebuild_hint in TARGET_SPECS:
+        expanded = sorted(root.glob(pattern))
+        if expanded:
+            for target in expanded:
+                matches.append((class_name, target, rebuild_hint))
+            continue
+
+        if any(ch in pattern for ch in "*?[]"):
+            continue
+        matches.append((class_name, root / pattern, rebuild_hint))
+    return matches
+
+
+def remove_path(path: Path) -> bool:
+    if not path.exists():
+        return False
+    if path.is_symlink() or path.is_file():
+        path.unlink(missing_ok=True)
+        return True
+    shutil.rmtree(path)
+    return True
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Preview or remove repo-local support residue under .runtime-cache/ "
+            "without touching copied evidence, output/, Docker, browser profiles, or shared caches."
+        )
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="preview removals without deleting anything")
+    mode.add_argument("--apply", action="store_true", help="delete the same support residue")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    mode = "apply" if args.apply else "dry-run"
+    root = repo_root()
+    print(
+        "[clean-support-state] maintainer-only lane; it only touches repo-local "
+        "support residue under .runtime-cache/ and leaves copied evidence, output/, "
+        "Docker state, browser profiles, and shared caches alone."
+    )
+
+    removed = 0
+    missing = 0
+    for class_name, target, rebuild_hint in match_targets(root):
+        rel_target = target.relative_to(root) if target.is_absolute() and target.is_relative_to(root) else target
+        if target.exists():
+            if mode == "dry-run":
+                print(
+                    f"[clean-support-state] would remove class={class_name} "
+                    f"path={rel_target} rebuild='{rebuild_hint}'"
+                )
+            else:
+                remove_path(target)
+                print(
+                    f"[clean-support-state] removed class={class_name} "
+                    f"path={rel_target} rebuild='{rebuild_hint}'"
+                )
+                removed += 1
+        else:
+            print(f"[clean-support-state] missing class={class_name} path={rel_target}")
+            missing += 1
+
+    print(f"clean-support-state done (mode={mode}, removed={removed}, missing={missing})")
+    print("next: ./.venv/bin/python scripts/ci/check_release_readiness.py --strict")
+    print("next: ./.venv/bin/python scripts/release/check_docker_surface.py --metadata-only")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/check_docker_surface.py
+++ b/scripts/release/check_docker_surface.py
@@ -5,11 +5,13 @@ import json
 import shutil
 import subprocess
 import tempfile
+import tomllib
 from pathlib import Path
 
 
 REPO_URL = "https://github.com/xiaojiou176-open/apple-notes-forensics"
 SERVER_NAME = "io.github.xiaojiou176-open/notestorelab-mcp"
+IMAGE_BASE = "ghcr.io/xiaojiou176-open/apple-notes-forensics"
 
 
 def _run(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -22,8 +24,15 @@ def _run(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _project_version(repo_root: Path) -> str:
+    pyproject = tomllib.loads((repo_root / "pyproject.toml").read_text(encoding="utf-8"))
+    return str(pyproject["project"]["version"])
+
+
 def collect_docker_surface_errors(repo_root: Path) -> list[str]:
     errors: list[str] = []
+    project_version = _project_version(repo_root)
+    local_image_tag = f"notestorelab:{project_version}"
 
     dockerfile = repo_root / "Dockerfile"
     dockerignore = repo_root / ".dockerignore"
@@ -45,14 +54,16 @@ def collect_docker_surface_errors(repo_root: Path) -> list[str]:
     readme_text = (repo_root / "README.md").read_text(encoding="utf-8")
     integrations_text = (repo_root / "INTEGRATIONS.md").read_text(encoding="utf-8")
     distribution_text = (repo_root / "DISTRIBUTION.md").read_text(encoding="utf-8")
-    if "docker build -t notestorelab:0.1.0 ." not in readme_text:
+    if f"docker build -t {local_image_tag} ." not in readme_text:
         errors.append("README.md must include the canonical docker build command")
-    if "docker run --rm notestorelab:0.1.0 notes-recovery demo" not in readme_text:
+    if f"docker run --rm {local_image_tag} notes-recovery demo" not in readme_text:
         errors.append("README.md must include the canonical docker demo command")
     if "--entrypoint notes-recovery-mcp" not in integrations_text:
         errors.append("INTEGRATIONS.md must show the MCP container entrypoint override")
     if "Docker-ready local container surface shipped" not in distribution_text:
         errors.append("DISTRIBUTION.md must describe the Docker-ready local container surface")
+    if IMAGE_BASE not in distribution_text:
+        errors.append("DISTRIBUTION.md must describe the canonical GHCR image target")
     if "not a hosted service" not in readme_text:
         errors.append("README.md must keep the container path out of hosted-service language")
 

--- a/skills/notestorelab-case-review/manifest.yaml
+++ b/skills/notestorelab-case-review/manifest.yaml
@@ -1,6 +1,6 @@
 name: notestorelab-case-review
 description: Guide one bounded NoteStore Lab case review without turning the repo into a hosted platform.
-version: 0.1.0
+version: 0.1.0.post1
 homepage: https://github.com/xiaojiou176-open/apple-notes-forensics
 repository: https://github.com/xiaojiou176-open/apple-notes-forensics
 license: MIT

--- a/tests/test_clean_support_state.py
+++ b/tests/test_clean_support_state.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "ops"
+    / "clean_support_state.py"
+)
+
+
+def write_file(path: Path, content: bytes = b"x") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+class CleanSupportStateTests(unittest.TestCase):
+    def test_dry_run_lists_supported_runtime_residue(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            write_file(root / ".runtime-cache" / "pypi-release" / "artifact.whl")
+            write_file(root / ".runtime-cache" / "history-rewrite-20260407T172244" / "rollback.bundle")
+            write_file(root / ".runtime-cache" / "lighthouse-pages" / "report.html")
+            write_file(root / ".runtime-cache" / "test-starter-bundles.zip")
+
+            result = subprocess.run(
+                ["python3", str(SCRIPT), "--dry-run"],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("class=pypi-release path=.runtime-cache/pypi-release", result.stdout)
+        self.assertIn(
+            "class=history-rewrite-rollback path=.runtime-cache/history-rewrite-20260407T172244",
+            result.stdout,
+        )
+        self.assertIn("class=pages-audit path=.runtime-cache/lighthouse-pages", result.stdout)
+        self.assertIn("class=bundle-archive path=.runtime-cache/test-starter-bundles.zip", result.stdout)
+
+    def test_apply_removes_matching_support_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            keep = root / ".runtime-cache" / "other" / "keep.txt"
+            write_file(keep)
+            target = root / ".runtime-cache" / "pypi-publish-attempt-20260407T173022" / "state.json"
+            write_file(target)
+
+            result = subprocess.run(
+                ["python3", str(SCRIPT), "--apply"],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(target.parent.exists())
+            self.assertTrue(keep.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- land the current distribution-truth sync wave for README, distribution docs, skill metadata, and docker surface truth
- add a repo-native dry-run/apply cleanup helper for local support residue under .runtime-cache
- keep PyPI as the canonical install surface and keep npm/GHCR claims truthful

## Verification
- ./.venv/bin/python scripts/release/check_skill_publish_readiness.py
- ./.venv/bin/python -m pytest tests/test_skill_publish_readiness.py tests/test_clean_support_state.py -q
- ./.venv/bin/python scripts/release/check_docker_surface.py --metadata-only
- ./.venv/bin/python scripts/ci/check_release_readiness.py --strict
- pre-commit run --all-files