### PR TITLE
[codex] add OpenHands and Glama distribution packaging

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -18,6 +18,9 @@ Use it when you need to answer:
 | Codex | yes, the official Codex plugin directory exists, but third-party official-directory submission is still coming soon | yes: `plugins/notestorelab-codex-plugin/` | not confirmed | public-ready Codex plugin bundle shipped; do not claim official Codex directory listing |
 | Claude Code | yes, official plugin and marketplace surfaces exist | yes: `plugins/notestorelab-claude-plugin/` plus root `.claude-plugin/marketplace.json` | not confirmed | submit-ready Claude Code marketplace artifact shipped; do not claim Anthropic-managed listing without fresh read-back |
 | OpenClaw | yes, the official ClawHub public registry exists | yes: `plugins/notestorelab-openclaw-bundle/` | not confirmed | public-ready compatible bundle shipped; do not claim live ClawHub or official OpenClaw listing |
+| OpenHands/extensions | yes, the official OpenHands public extensions registry exists | yes: `public-skills/notestorelab-case-review/` plus canonical `skills/notestorelab-case-review/` | not confirmed | OpenHands/extensions-friendly public skill folder shipped; do not claim a live OpenHands/extensions listing without fresh PR/read-back |
+| Glama | yes, the public Add Server and hosted MCP surface exists | yes: `glama.json`, `Dockerfile`, and the canonical GHCR target | not confirmed | repo-owned Glama-ready metadata and Docker surface shipped; do not claim a live Glama listing without fresh Glama-side read-back |
+| Docker MCP Catalog | yes, the official curated Docker MCP Catalog exists | yes: `Dockerfile`, `scripts/release/check_docker_surface.py`, and the canonical GHCR target | not confirmed | Docker-ready local container surface shipped; do not claim a live Docker catalog listing without fresh Docker-side submission/read-back |
 
 ## Repo-Owned Artifacts
 
@@ -27,7 +30,9 @@ Use it when you need to answer:
 - `plugins/notestorelab-claude-plugin/`
 - `plugins/notestorelab-openclaw-bundle/`
 - `skills/notestorelab-case-review/`
+- `public-skills/notestorelab-case-review/`
 - `.claude-plugin/marketplace.json`
+- `glama.json`
 - `server.json`
 - `scripts/release/build_distribution_bundles.py`
 - `Dockerfile`
@@ -54,6 +59,17 @@ This means the repository can now truthfully say "independent skill surface
 shipped" or "independent skill ready" without claiming any official directory
 listing.
 
+For public skill-folder registries, the portable listing packet now lives at
+`public-skills/notestorelab-case-review/`.
+
+That packet is intentionally separate from the canonical skill SSOT:
+
+- canonical truth still lives in `skills/notestorelab-case-review/`
+- the public packet adds semver-ready listing metadata for ClawHub-style
+  publication
+- the public packet adds an OpenHands/extensions-facing README so external
+  reviewers do not need to infer the install story from internal bundle paths
+
 ## Package Surface
 
 The canonical installable package surface for this repository is PyPI:
@@ -62,6 +78,8 @@ The canonical installable package surface for this repository is PyPI:
 - live package truth comes from PyPI JSON read-back plus install smoke
 - `server.json` points at the PyPI package because the current MCP publication
   story is Python-first
+- this is the intended PyPI package identifier and version for the current repo
+  contract: `apple-notes-forensics==0.1.0.post1`
 
 There is no tracked npm package surface in the current public contract:
 
@@ -92,6 +110,12 @@ The canonical live-image target, if and when fresh publish proof exists, is:
 
 Do not claim a live OCI image without fresh GHCR push read-back and pull/read
 verification.
+
+`glama.json` is now the repo-owned metadata side of the Glama story. It makes
+the intended maintainer identity explicit, but it does **not** prove a live
+Glama listing or hosted deployment by itself.
+
+Do not claim a live Glama listing without fresh Glama-side read-back.
 
 ## Proof Loops
 
@@ -142,6 +166,8 @@ The repo-side publish-readiness proof command is:
 - "submit-ready Claude Code marketplace artifact shipped"
 - "OpenClaw-compatible bundle shipped"
 - "independent skill surface shipped"
+- "OpenHands/extensions-friendly public skill folder shipped"
+- "repo-owned Glama-ready metadata shipped"
 - "Docker-ready local container surface shipped"
 - "`ghcr.io/xiaojiou176-open/apple-notes-forensics` is the canonical live-image target, but live-image claims still require fresh GHCR push and pull read-back"
 
@@ -153,6 +179,7 @@ The repo-side publish-readiness proof command is:
 - "official Codex plugin directory listing" without OpenAI-managed listing proof
 - "official Anthropic marketplace listing" without fresh marketplace read-back
 - "live ClawHub listing" without fresh OpenClaw-side listing proof
+- "live OpenHands/extensions listing" without fresh OpenHands PR/read-back
 - "official npm package" or "npm is the canonical install path" without a real shipped npm package surface
 - "officially listed skill" without fresh host-side read-back
 - "hosted service" or "multi-tenant platform" for the Docker surface

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -10,7 +10,7 @@ ecosystem without overstating what is actually shipped.
 | MCP | Primary | MCP is a real shipped surface, not a future placeholder | `notes-recovery-mcp`, `notes_recovery/mcp/server.py`, README protocol section |
 | Codex | Primary | the repo already exposes a local MCP surface, stable review-safe artifacts, and a tracked Codex plugin bundle | `notes-recovery-mcp`, `review_index.md`, manifests, `plugins/notestorelab-codex-plugin/` |
 | Claude Code | Primary | same reason as Codex, plus a tracked marketplace-ready plugin that matches Claude Code's public plugin surface | README, `notes-recovery-mcp`, `ai-review`, `ask-case`, `.claude-plugin/marketplace.json`, `plugins/notestorelab-claude-plugin/` |
-| OpenHands | Secondary / comparison | the repo can be consumed by local agents, but it does not ship a dedicated OpenHands integration contract | CLI + MCP are real; no OpenHands-specific runner or docs surface |
+| OpenHands | OpenHands/extensions-ready public skill folder | the repo now ships a public skill-folder packet for OpenHands/extensions while keeping runtime claims on local CLI + MCP only | `public-skills/notestorelab-case-review/`, `skills/notestorelab-case-review/`, CLI + MCP |
 | OpenCode | Secondary / comparison | the repo exposes a clean local tool / MCP story, but no dedicated OpenCode-specific integration layer | CLI + MCP are real; no OpenCode-specific contract or SDK |
 | OpenClaw | Public-ready compatible bundle | OpenClaw can consume the shipped compatible bundle archive, but this repo still does not claim a live ClawHub listing | `scripts/release/build_distribution_bundles.py`, `DISTRIBUTION.md` |
 

--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -69,6 +69,7 @@ Public-ready host artifacts now shipped in-repo:
 - Claude Code plugin bundle: `plugins/notestorelab-claude-plugin/`
 - Claude marketplace manifest: `.claude-plugin/marketplace.json`
 - OpenClaw-compatible bundle build: `.venv/bin/python scripts/release/build_distribution_bundles.py --out-dir ./dist`
+- OpenHands/extensions-friendly public skill folder: `public-skills/notestorelab-case-review/`
 
 Fast host smoke checklist:
 
@@ -174,6 +175,7 @@ Current design intent:
 | Claude Code marketplace-ready plugin | shipped | use `.claude-plugin/marketplace.json` plus `plugins/notestorelab-claude-plugin/` |
 | OpenClaw-compatible bundle | shipped | build the local archive from `plugins/notestorelab-openclaw-bundle/`; do not claim a live ClawHub listing yet |
 | canonical independent skill surface | shipped | use `skills/notestorelab-case-review/` as the canonical independent skill surface; plugin/starter skill files are host-specific derived copies |
+| OpenHands/extensions-friendly public skill folder | shipped | use `public-skills/notestorelab-case-review/` when you need a standalone skill-folder packet for OpenHands/extensions or similar registries |
 | repo-owned host plugin | shipped as installable bundles | the shipped plugins are installable surfaces, but installability does not imply official listing |
 
 ## Container Surface
@@ -215,6 +217,10 @@ describe that image as live until fresh GHCR push and pull read-back exist.
 `docker-compose` is intentionally absent here. This repo is a local CLI / MCP
 workbench, not a multi-service stack. The container image is the repo-side
 maximum we can claim truthfully today; it does not prove a live Glama listing.
+
+The Glama metadata side now lives in `glama.json`. That file is enough to make
+the Add Server handoff explicit for a Docker-backed submission, but it still
+does not prove a live Glama listing or hosted runtime by itself.
 
 ## API / SDK Status
 

--- a/README.md
+++ b/README.md
@@ -357,6 +357,12 @@ package, and treat the plugin/starter skill files as host-specific derived
 copies. That makes the skill independently referenceable without pretending it
 is already officially listed anywhere.
 
+For OpenHands/extensions and ClawHub-style submissions, the repo now also ships
+an OpenHands/extensions-friendly public skill folder at
+`public-skills/notestorelab-case-review/`. Treat that packet as the
+portable listing lane, while `skills/notestorelab-case-review/` remains the
+canonical skill text.
+
 When you want the repo-side metadata/build-readiness gate before the next PyPI
 version bump, run:
 
@@ -375,7 +381,8 @@ Practical host notes:
 Current integration fit:
 
 - **Primary fit**: MCP, Codex, Claude Code
-- **Secondary / comparison fit**: OpenHands, OpenCode
+- **OpenHands/extensions-friendly public skill folder**: `public-skills/notestorelab-case-review/`
+- **Secondary / comparison fit**: OpenCode
 - **Not a primary front-door claim**: OpenClaw, hosted portals, generic AI-agent platforms
 
 Builder-facing status today:
@@ -388,6 +395,7 @@ Builder-facing status today:
 | thin SDK | not shipped | future path only, after the shared case/MCP contract is locked |
 | repo-owned host bundles | shipped | use `plugins/`, `.claude-plugin/`, `server.json`, and `scripts/release/build_distribution_bundles.py` |
 | canonical independent skill surface | shipped | use `skills/notestorelab-case-review/` as the only SSOT skill surface; plugin/starter copies are derived packaging |
+| OpenHands/extensions-friendly public skill folder | shipped | use `public-skills/notestorelab-case-review/` for OpenHands/extensions or ClawHub-style skill submissions |
 | official marketplace/catalog listing | not shipped | public-ready artifacts do not imply official listing or publish read-back |
 
 ## Docker Surface
@@ -434,6 +442,16 @@ live registry image until fresh push and pull verification both succeed.
 
 The container image is a reproducible local runtime, not a hosted portal, not
 an API gateway, and not proof of any live Glama or OCI catalog listing.
+
+The repo-side Glama metadata surface is now explicit as well:
+
+- `glama.json`
+- `Dockerfile`
+- `ghcr.io/xiaojiou176-open/apple-notes-forensics:0.1.0.post1`
+
+That is enough to prepare a Glama Add Server submission or a Docker-first
+catalog conversation. It is still not proof of a live Glama listing until fresh
+Glama-side read-back exists.
 
 Use the dedicated builder notes in [INTEGRATIONS.md](./INTEGRATIONS.md) and the
 ecosystem binding matrix in [ECOSYSTEM.md](./ECOSYSTEM.md) before you describe

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "xiaojiou176"
+  ]
+}

--- a/public-skills/README.md
+++ b/public-skills/README.md
@@ -1,0 +1,43 @@
+# NoteStore Lab Public Skill Pack
+
+These files are the public-safe subset of the repo's skill distribution story.
+
+What this pack is for:
+
+- keeping OpenHands/extensions and ClawHub-style submissions on a repo-owned
+  folder instead of ad hoc copy-paste
+- keeping public wording aligned across the canonical skill surface, builder
+  docs, and marketplace-facing packaging
+- giving hosts and reviewers one portable folder they can inspect without
+  inheriting maintainer-only task-board or archive context
+
+What this pack is not:
+
+- a dump of `.agents/skills/`
+- proof of a live listing on OpenHands/extensions, ClawHub, Glama, or Docker
+  MCP Catalog
+- a hosted runtime or remote MCP deployment
+
+Current public-safe contents:
+
+- `notestorelab-case-review/`
+  - OpenHands/extensions-friendly public skill folder
+  - ClawHub-style manifest with semver-ready listing metadata
+  - one derived copy of the canonical `skills/notestorelab-case-review/SKILL.md`
+
+Public-safe inclusion test:
+
+- keep a file here only if it still works as repo-scoped guidance without
+  private machine paths, owner-session assumptions, or task-board state
+- pull it back out if it starts depending on maintainer-only closeout rituals
+- keep official-listing claims outside this pack unless fresh platform-side
+  read-back exists
+
+Use this pack as the copyable skill-folder lane for OpenHands/extensions or a
+ClawHub-style publish flow. Pair it with the root-level public contract files
+when you need the full product boundary:
+
+- `README.md`
+- `DISTRIBUTION.md`
+- `INTEGRATIONS.md`
+- `ECOSYSTEM.md`

--- a/public-skills/notestorelab-case-review/README.md
+++ b/public-skills/notestorelab-case-review/README.md
@@ -1,0 +1,43 @@
+# NoteStore Lab Case Review Public Skill
+
+This folder is the OpenHands/extensions-friendly and ClawHub-style public skill
+packet for NoteStore Lab.
+
+## Purpose
+
+Use it when you want one portable skill folder that keeps the NoteStore Lab
+case-review story honest:
+
+- one bounded case root at a time
+- copied evidence only
+- derived artifacts first
+- local stdio MCP instead of a hosted Notes platform claim
+
+## What this packet includes
+
+- `SKILL.md`
+  - the canonical case-review instructions copied from the repo SSOT skill
+- `manifest.yaml`
+  - repo-owned listing metadata for ClawHub-style skill publication
+
+## Best-fit hosts
+
+- OpenHands/extensions contribution flow
+- ClawHub-style skill publication
+- repo-local skill import flows that expect a standalone folder
+
+## What this packet must not claim
+
+- no official OpenHands/extensions listing without fresh PR/read-back
+- no live ClawHub listing without fresh host-side read-back
+- no hosted Glama deployment, Docker catalog listing, or remote MCP lane
+- no direct mutation of the live Apple Notes store
+
+## Source of truth
+
+The canonical skill text still lives at:
+
+- `skills/notestorelab-case-review/SKILL.md`
+
+This folder is a public-facing derived packet. If the canonical skill changes,
+copy the updated `SKILL.md` here before publishing.

--- a/public-skills/notestorelab-case-review/SKILL.md
+++ b/public-skills/notestorelab-case-review/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: notestorelab-case-review
+description: Guide one bounded NoteStore Lab case review without turning the repo into a hosted platform.
+---
+
+# NoteStore Lab Case Review
+
+Use this skill when an agent is reviewing one NoteStore Lab case root or the
+public-safe demo surface.
+
+## Product truth
+
+- Recovery is the main product.
+- AI and MCP are review layers, not the recovery engine.
+- Stay local, copy-first, and case-root-driven.
+- Prefer derived artifacts before raw copied evidence.
+- Do not treat the live Notes store as a target.
+- Do not describe this repo as a hosted or multi-tenant platform.
+
+## Preferred evidence order
+
+1. Read `review_index.md`.
+2. Read the verification preview and pipeline summary.
+3. Use `notes-recovery ask-case` for one bounded operator question.
+4. Use `notes-recovery case-diff` only when comparing two case roots.
+5. Use `notes-recovery public-safe-export` when you need a shareable bundle.
+
+## Bounded MCP entry
+
+```bash
+notes-recovery-mcp --case-dir ./output/Notes_Forensics_<run_ts>
+```
+
+## Proof path
+
+1. `notes-recovery demo`
+2. `notes-recovery ai-review --demo`
+3. `notes-recovery ask-case --demo --question "What should I inspect first?"`
+4. `notes-recovery doctor`
+
+## Truth language
+
+- Good: "repo-owned independent skill surface"
+- Good: "local copy-first case review skill"
+- Forbidden: "officially listed skill" without fresh host-side read-back
+- Forbidden: "hosted Notes recovery platform"

--- a/public-skills/notestorelab-case-review/manifest.yaml
+++ b/public-skills/notestorelab-case-review/manifest.yaml
@@ -1,0 +1,34 @@
+schema_version: 1
+artifact: public-skill-listing-manifest
+
+skill:
+  name: notestorelab-case-review
+  display_name: NoteStore Lab Case Review
+  version: 1.0.0
+  entrypoint: SKILL.md
+  package_shape: skill-folder
+
+registry_targets:
+  clawhub:
+    status: ready-but-not-listed
+    package_shape: skill-folder
+    submit_via: openclaw skill publish .
+  openhands-extensions:
+    status: folder-ready
+    package_shape: skill-folder
+    submit_via: submit this folder as skills/notestorelab-case-review/ in OpenHands/extensions
+
+boundaries:
+  product_identity: Copy-first Apple Notes case review skill for NoteStore Lab.
+  canonical_repo_version: 0.1.0.post1
+  official_listing_state: not-yet-listed
+  not_claimed:
+    - No live ClawHub listing exists yet
+    - No live OpenHands/extensions listing exists yet
+    - No hosted Glama deployment exists yet
+    - No live Docker MCP Catalog listing exists yet
+
+pair_with:
+  - SKILL.md
+  - README.md
+  - ../../DISTRIBUTION.md

--- a/scripts/release/check_glama_surface.py
+++ b/scripts/release/check_glama_surface.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+GLAMA_SCHEMA = "https://glama.ai/mcp/schemas/server.json"
+GLAMA_MAINTAINER = "xiaojiou176"
+IMAGE_BASE = "ghcr.io/xiaojiou176-open/apple-notes-forensics"
+
+
+def collect_glama_surface_errors(repo_root: Path) -> list[str]:
+    errors: list[str] = []
+
+    glama_json = repo_root / "glama.json"
+    if not glama_json.exists():
+        return ["missing glama.json"]
+
+    payload = json.loads(glama_json.read_text(encoding="utf-8"))
+    if payload.get("$schema") != GLAMA_SCHEMA:
+        errors.append("glama.json must keep the official Glama schema URL")
+    maintainers = payload.get("maintainers")
+    if not isinstance(maintainers, list) or GLAMA_MAINTAINER not in maintainers:
+        errors.append("glama.json must list xiaojiou176 as a maintainer")
+
+    if not (repo_root / "Dockerfile").exists():
+        errors.append("Glama surface requires a Dockerfile")
+
+    readme_text = (repo_root / "README.md").read_text(encoding="utf-8")
+    distribution_text = (repo_root / "DISTRIBUTION.md").read_text(encoding="utf-8")
+    integrations_text = (repo_root / "INTEGRATIONS.md").read_text(encoding="utf-8")
+
+    for token in (
+        "glama.json",
+        "OpenHands/extensions-friendly public skill folder",
+        IMAGE_BASE,
+    ):
+        if token not in readme_text:
+            errors.append(f"README.md is missing Glama surface token: {token}")
+
+    for token in (
+        "Glama",
+        "glama.json",
+        "Do not claim a live Glama listing",
+        IMAGE_BASE,
+    ):
+        if token not in distribution_text:
+            errors.append(f"DISTRIBUTION.md is missing Glama surface token: {token}")
+
+    for token in (
+        "Glama",
+        "glama.json",
+        IMAGE_BASE,
+    ):
+        if token not in integrations_text:
+            errors.append(f"INTEGRATIONS.md is missing Glama surface token: {token}")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    errors = collect_glama_surface_errors(repo_root)
+    payload = {"ok": not errors, "errors": errors}
+    print(json.dumps(payload, indent=2, ensure_ascii=True))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/check_skill_publish_readiness.py
+++ b/scripts/release/check_skill_publish_readiness.py
@@ -23,9 +23,12 @@ DERIVED_SKILL_PATHS = (
     Path("starter-bundles/claude-code/plugins/notestorelab/skills/notestorelab-mcp/SKILL.md"),
     Path("plugins/notestorelab-openclaw-bundle/workspace/skills/notestorelab/SKILL.md"),
     Path("starter-bundles/openclaw/workspace/skills/notestorelab/SKILL.md"),
+    Path("public-skills/notestorelab-case-review/SKILL.md"),
 )
 REPO_URL = "https://github.com/xiaojiou176-open/apple-notes-forensics"
 CANONICAL_NAME = "notestorelab-case-review"
+PUBLIC_SKILL_DIR = Path("public-skills/notestorelab-case-review")
+PUBLIC_SKILL_SEMVER = "1.0.0"
 
 
 def _load_pyproject(repo_root: Path) -> dict[str, object]:
@@ -125,6 +128,46 @@ def collect_skill_publish_errors(repo_root: Path) -> list[str]:
     if _manifest_scalar(manifest_text, "entrypoint") != "./SKILL.md":
         errors.append("manifest.yaml entrypoint must stay ./SKILL.md")
 
+    public_skill_dir = repo_root / PUBLIC_SKILL_DIR
+    public_skill_manifest = public_skill_dir / "manifest.yaml"
+    public_skill_readme = public_skill_dir / "README.md"
+    if not public_skill_dir.exists():
+        errors.append(f"missing public skill directory: {PUBLIC_SKILL_DIR}")
+    if not public_skill_manifest.exists():
+        errors.append(f"missing public skill manifest: {public_skill_manifest.relative_to(repo_root)}")
+    if not public_skill_readme.exists():
+        errors.append(f"missing public skill README: {public_skill_readme.relative_to(repo_root)}")
+    if public_skill_manifest.exists():
+        public_manifest_text = public_skill_manifest.read_text(encoding="utf-8")
+        for token in (
+            "schema_version: 1",
+            "artifact: public-skill-listing-manifest",
+            "name: notestorelab-case-review",
+            "version: 1.0.0",
+            "display_name: NoteStore Lab Case Review",
+            "package_shape: skill-folder",
+            "clawhub:",
+            "openhands-extensions:",
+            "status: ready-but-not-listed",
+            "status: folder-ready",
+            "submit_via: openclaw skill publish .",
+            "submit_via: submit this folder as skills/notestorelab-case-review/ in OpenHands/extensions",
+            "canonical_repo_version: 0.1.0.post1",
+            "official_listing_state: not-yet-listed",
+        ):
+            if token not in public_manifest_text:
+                errors.append(f"public skill manifest is missing required token: {token}")
+    if public_skill_readme.exists():
+        public_readme_text = public_skill_readme.read_text(encoding="utf-8")
+        for token in (
+            "OpenHands/extensions-friendly",
+            "ClawHub-style",
+            "skills/notestorelab-case-review/SKILL.md",
+            "no official OpenHands/extensions listing without fresh PR/read-back",
+        ):
+            if token not in public_readme_text:
+                errors.append(f"public skill README is missing required token: {token}")
+
     codex_plugin_payload = _load_json(
         repo_root / "plugins/notestorelab-codex-plugin/.codex-plugin/plugin.json"
     )
@@ -149,12 +192,21 @@ def collect_skill_publish_errors(repo_root: Path) -> list[str]:
     readme_text = (repo_root / "README.md").read_text(encoding="utf-8")
     distribution_text = (repo_root / "DISTRIBUTION.md").read_text(encoding="utf-8")
     integrations_text = (repo_root / "INTEGRATIONS.md").read_text(encoding="utf-8")
+    ecosystem_text = (repo_root / "ECOSYSTEM.md").read_text(encoding="utf-8")
     if "skills/notestorelab-case-review/" not in readme_text:
         errors.append("README.md must mention the canonical independent skill surface")
+    if "public-skills/notestorelab-case-review/" not in readme_text:
+        errors.append("README.md must mention the OpenHands/ClawHub-facing public skill folder")
     if "independent skill surface" not in distribution_text:
         errors.append("DISTRIBUTION.md must describe the independent skill surface truthfully")
+    if "OpenHands/extensions" not in distribution_text:
+        errors.append("DISTRIBUTION.md must describe the OpenHands/extensions listing boundary")
     if "canonical independent skill surface" not in integrations_text:
         errors.append("INTEGRATIONS.md must describe the canonical independent skill surface")
+    if "OpenHands/extensions-friendly public skill folder" not in integrations_text:
+        errors.append("INTEGRATIONS.md must describe the OpenHands-facing public skill folder")
+    if "OpenHands/extensions-ready public skill folder" not in ecosystem_text:
+        errors.append("ECOSYSTEM.md must describe the OpenHands-facing public skill lane")
 
     return errors
 

--- a/tests/test_glama_surface.py
+++ b/tests/test_glama_surface.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.release.check_glama_surface import collect_glama_surface_errors
+
+
+def test_collect_glama_surface_errors_passes_for_repo_root() -> None:
+    errors = collect_glama_surface_errors(Path.cwd())
+    assert errors == []


### PR DESCRIPTION
## Summary
- add a tracked `public-skills/notestorelab-case-review/` packet for OpenHands/extensions and ClawHub-style submissions
- add repo-owned Glama metadata plus release checks for the Glama/Docker packaging surface
- tighten README, DISTRIBUTION, INTEGRATIONS, and ECOSYSTEM so the new distribution lanes stay truthful

## Test Plan
- [x] `./.venv/bin/python -m pytest tests/test_skill_publish_readiness.py tests/test_glama_surface.py tests/test_docker_surface.py tests/test_distribution_bundles.py tests/test_repo_surface.py tests/test_release_readiness.py -q`
- [x] `./.venv/bin/python scripts/release/check_skill_publish_readiness.py`
- [x] `./.venv/bin/python scripts/release/check_glama_surface.py`
- [x] `./.venv/bin/python scripts/release/check_docker_surface.py --metadata-only`
- [x] `./.venv/bin/python scripts/release/check_docker_surface.py`
- [x] `./.venv/bin/python scripts/ci/check_discovery_surface_contract.py`
- [x] `./.venv/bin/python scripts/ci/check_public_story_truth.py`
- [x] `./.venv/bin/python scripts/ci/check_release_readiness.py --strict`

## Breaking Changes
None

## Rollout / Risk
- Risk: Low
- Rollback: revert this PR to remove the new public skill packet and Glama metadata surface

## Checklist
- [x] Self-reviewed code
- [x] Documentation updated
- [x] Tests updated
