### PR TITLE
[codex] sync live registry and GHCR truth

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -14,7 +14,7 @@ Use it when you need to answer:
 
 | Surface | Official public surface exists | Repo-owned artifact shipped | Already listed | Current truthful claim |
 | --- | --- | --- | --- | --- |
-| MCP Registry | yes, the official MCP Registry exists and is still documented as a preview surface | yes: `server.json` and `notes-recovery-mcp` | not confirmed | live PyPI package now exists at `apple-notes-forensics==0.1.0.post1`, with fresh JSON read-back and install smoke; `server.json` is aligned with that live package version, but MCP Registry listing itself is still not confirmed without fresh registry read-back |
+| MCP Registry | yes, the official MCP Registry exists and is still documented as a preview surface | yes: `server.json` and `notes-recovery-mcp` | yes | live PyPI package now exists at `apple-notes-forensics==0.1.0.post1`, `server.json` is aligned with that live package version, and the official MCP Registry now returns `io.github.xiaojiou176-open/notestorelab-mcp` as an active listing with fresh read-back |
 | Codex | yes, the official Codex plugin directory exists, but third-party official-directory submission is still coming soon | yes: `plugins/notestorelab-codex-plugin/` | not confirmed | public-ready Codex plugin bundle shipped; do not claim official Codex directory listing |
 | Claude Code | yes, official plugin and marketplace surfaces exist | yes: `plugins/notestorelab-claude-plugin/` plus root `.claude-plugin/marketplace.json` | not confirmed | submit-ready Claude Code marketplace artifact shipped; do not claim Anthropic-managed listing without fresh read-back |
 | OpenClaw | yes, the official ClawHub public registry exists | yes: `plugins/notestorelab-openclaw-bundle/` | not confirmed | public-ready compatible bundle shipped; do not claim live ClawHub or official OpenClaw listing |
@@ -100,16 +100,23 @@ Docker-ready local container surface shipped:
 - `scripts/release/check_docker_surface.py`
 
 This container path is for local reproducibility of the CLI and stdio MCP
-surface. It is not proof of a hosted deployment, multi-tenant backend, or live
-Glama listing.
+surface. A live GHCR image is now verified with fresh push, manifest, pull, and
+demo read-back. That is still not proof of a hosted deployment, multi-tenant
+backend, live Glama listing, or Docker MCP Catalog listing.
 
 The canonical live-image target, if and when fresh publish proof exists, is:
 
 - `ghcr.io/xiaojiou176-open/apple-notes-forensics:0.1.0.post1`
 - optional convenience tag: `ghcr.io/xiaojiou176-open/apple-notes-forensics:latest`
 
-Do not claim a live OCI image without fresh GHCR push read-back and pull/read
-verification.
+A live OCI image is now confirmed at:
+
+- `ghcr.io/xiaojiou176-open/apple-notes-forensics:0.1.0.post1`
+- `ghcr.io/xiaojiou176-open/apple-notes-forensics:latest`
+
+The verified current digest is:
+
+- `sha256:c1267822e3966fbc22f3a3a996a4b0cae67c2df8d94d35b14f93c5a90d9aab40`
 
 `glama.json` is now the repo-owned metadata side of the Glama story. It makes
 the intended maintainer identity explicit, but it does **not** prove a live
@@ -143,13 +150,15 @@ claude plugin validate .
 
 ### MCP Registry listing boundary
 
-`server.json` is still only the metadata side of the MCP Registry story.
+`server.json` is the metadata side of the MCP Registry story, and that story is
+now live for the current version.
 
-Fresh PyPI read-back now confirms that PyPI serves
-`apple-notes-forensics==0.1.0.post1`, and fresh install smoke confirms that the
-published package is installable. That does **not** prove that the MCP
-Registry, or any other official directory, has accepted, listed, or rendered
-the package.
+Fresh PyPI read-back confirms that PyPI serves
+`apple-notes-forensics==0.1.0.post1`, fresh install smoke confirms that the
+published package is installable, and fresh registry read-back confirms that
+the official MCP Registry now returns
+`io.github.xiaojiou176-open/notestorelab-mcp` as an active listing for
+`0.1.0.post1`.
 
 The repo-side publish-readiness proof command is:
 
@@ -162,6 +171,7 @@ The repo-side publish-readiness proof command is:
 - "live PyPI package `apple-notes-forensics==0.1.0.post1` verified with fresh JSON read-back"
 - "`server.json` is aligned with the live PyPI version `0.1.0.post1`"
 - "PyPI is the canonical installable package surface for this repository today"
+- "official MCP Registry listing is live for `io.github.xiaojiou176-open/notestorelab-mcp` at `0.1.0.post1`"
 - "public-ready Codex plugin bundle shipped"
 - "submit-ready Claude Code marketplace artifact shipped"
 - "OpenClaw-compatible bundle shipped"
@@ -169,7 +179,7 @@ The repo-side publish-readiness proof command is:
 - "OpenHands/extensions-friendly public skill folder shipped"
 - "repo-owned Glama-ready metadata shipped"
 - "Docker-ready local container surface shipped"
-- "`ghcr.io/xiaojiou176-open/apple-notes-forensics` is the canonical live-image target, but live-image claims still require fresh GHCR push and pull read-back"
+- "live GHCR image verified at `ghcr.io/xiaojiou176-open/apple-notes-forensics:0.1.0.post1` and `:latest`"
 
 ## Forbidden Claims
 

--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -138,9 +138,11 @@ or registry listings.
 
 For MCP Registry publication, `server.json` is still only the metadata layer.
 Fresh PyPI read-back now confirms a live package at
-`apple-notes-forensics==0.1.0.post1`, but that does **not** prove an MCP
-Registry listing by itself. Use [DISTRIBUTION.md](./DISTRIBUTION.md) when you
-need the current listing or live-package truth.
+`apple-notes-forensics==0.1.0.post1`, and fresh registry read-back now confirms
+an active official MCP Registry listing for
+`io.github.xiaojiou176-open/notestorelab-mcp`. Use
+[DISTRIBUTION.md](./DISTRIBUTION.md) when you need the current listing or
+live-package truth.
 
 Fresh PyPI install path:
 
@@ -209,10 +211,11 @@ docker run --rm -i \
   --case-dir /cases/Notes_Forensics_<run_ts>
 ```
 
-If you need a canonical live-image target later, use
-`ghcr.io/xiaojiou176-open/apple-notes-forensics:0.1.0.post1`, and treat
-`latest` as a convenience tag rather than the sole source of truth. Do not
-describe that image as live until fresh GHCR push and pull read-back exist.
+The canonical live-image target is now verified at
+`ghcr.io/xiaojiou176-open/apple-notes-forensics:0.1.0.post1`, with `latest`
+as a convenience tag that currently resolves to the same digest. Keep
+describing GHCR as an OCI/package surface, not as proof of a live Glama or
+Docker catalog listing.
 
 `docker-compose` is intentionally absent here. This repo is a local CLI / MCP
 workbench, not a multi-service stack. The container image is the repo-side

--- a/README.md
+++ b/README.md
@@ -339,11 +339,12 @@ Those public-ready surfaces live under `plugins/`, `.claude-plugin/`, and
 ```
 
 For the MCP Registry specifically, `server.json` is still only the metadata
-layer. Fresh PyPI read-back now confirms a live package at
-`apple-notes-forensics==0.1.0.post1`, and fresh install smoke confirms that
-the published package is installable now. That does **not** by itself prove an
-MCP Registry listing; use [DISTRIBUTION.md](./DISTRIBUTION.md) for the current
-listing boundary.
+layer. Fresh PyPI read-back confirms a live package at
+`apple-notes-forensics==0.1.0.post1`, fresh install smoke confirms that the
+published package is installable now, and fresh registry read-back confirms an
+active official MCP Registry listing for
+`io.github.xiaojiou176-open/notestorelab-mcp`. Use
+[DISTRIBUTION.md](./DISTRIBUTION.md) for the exact listing boundary.
 
 When you want the live package directly from PyPI, install:
 
@@ -435,10 +436,9 @@ docker run --rm -i \
   --case-dir /cases/Notes_Forensics_<run_ts>
 ```
 
-If you later publish a registry image, the canonical target is
+The canonical registry image is now live at
 `ghcr.io/xiaojiou176-open/apple-notes-forensics:0.1.0.post1`, with `latest`
-as an optional convenience tag only after matching read-back. Do not claim a
-live registry image until fresh push and pull verification both succeed.
+as a convenience tag that currently resolves to the same verified digest.
 
 The container image is a reproducible local runtime, not a hosted portal, not
 an API gateway, and not proof of any live Glama or OCI catalog listing.


### PR DESCRIPTION
## Summary
- update distribution docs to reflect the live official MCP Registry listing for `io.github.xiaojiou176-open/notestorelab-mcp`
- update README and integration docs to reflect the verified GHCR image truth
- keep the repo-owned distribution story aligned with fresh platform read-back

## Test Plan
- [x] `./.venv/bin/python scripts/release/check_glama_surface.py`
- [x] `./.venv/bin/python scripts/release/check_docker_surface.py --metadata-only`
- [x] `./.venv/bin/python scripts/ci/check_public_story_truth.py`
- [x] `./.venv/bin/python scripts/ci/check_release_readiness.py --strict`
- [x] `./.venv/bin/python -m pytest tests/test_glama_surface.py tests/test_docker_surface.py tests/test_distribution_bundles.py tests/test_release_readiness.py -q`

## Breaking Changes
None
