### PR TITLE
[codex] sync ClawHub publish command wording

### DIFF
--- a/public-skills/notestorelab-case-review/manifest.yaml
+++ b/public-skills/notestorelab-case-review/manifest.yaml
@@ -12,7 +12,7 @@ registry_targets:
   clawhub:
     status: ready-but-not-listed
     package_shape: skill-folder
-    submit_via: openclaw skill publish .
+    submit_via: clawhub publish . --slug notestorelab-case-review --name "NoteStore Lab Case Review" --version 1.0.0 --tags apple-notes,forensics,incident-response,mcp
   openhands-extensions:
     status: folder-ready
     package_shape: skill-folder

--- a/scripts/release/check_skill_publish_readiness.py
+++ b/scripts/release/check_skill_publish_readiness.py
@@ -150,7 +150,7 @@ def collect_skill_publish_errors(repo_root: Path) -> list[str]:
             "openhands-extensions:",
             "status: ready-but-not-listed",
             "status: folder-ready",
-            "submit_via: openclaw skill publish .",
+            "submit_via: clawhub publish .",
             "submit_via: submit this folder as skills/notestorelab-case-review/ in OpenHands/extensions",
             "canonical_repo_version: 0.1.0.post1",
             "official_listing_state: not-yet-listed",


### PR DESCRIPTION
## Summary
- update the public skill packet to use the current `clawhub publish` command wording
- align the local skill readiness check with the current ClawHub CLI surface

## Test Plan
- [x] `./.venv/bin/python scripts/release/check_skill_publish_readiness.py`

## Breaking Changes
None
