### PR TITLE
[codex] harden NoteStore Lab public skill package

### DIFF
--- a/public-skills/notestorelab-case-review/README.md
+++ b/public-skills/notestorelab-case-review/README.md
@@ -3,28 +3,50 @@
 This folder is the OpenHands/extensions-friendly and ClawHub-style public skill
 packet for NoteStore Lab.
 
-## Purpose
+## What this skill teaches an agent
 
-Use it when you want one portable skill folder that keeps the NoteStore Lab
-case-review story honest:
+This is not just a label for Apple Notes. It teaches an agent four concrete
+things:
 
-- one bounded case root at a time
-- copied evidence only
-- derived artifacts first
-- local stdio MCP instead of a hosted Notes platform claim
+1. how to install or launch the NoteStore Lab MCP surface
+2. how to prove the review flow on public-safe demo artifacts first
+3. how to review one copied case root without touching the live Notes store
+4. how to ask bounded questions from derived artifacts instead of guessing
 
 ## What this packet includes
 
 - `SKILL.md`
-  - the canonical case-review instructions copied from the repo SSOT skill
+  - the concise skill entry point for progressive disclosure
 - `manifest.yaml`
-  - repo-owned listing metadata for ClawHub-style skill publication
+  - listing metadata for ClawHub-style publication
+- `references/install-and-mcp.md`
+  - exact install and MCP wiring examples
+- `references/usage-and-proof.md`
+  - first-success flow, real prompts, and proof/demo links
+
+## First-success path
+
+If a reviewer wants to understand the skill quickly, use this order:
+
+1. read `SKILL.md`
+2. open `references/install-and-mcp.md`
+3. run the public-safe proof path from `references/usage-and-proof.md`
+4. inspect the public proof links before claiming anything is officially listed
+
+## Demo / proof links
+
+- Landing: https://xiaojiou176-open.github.io/apple-notes-forensics/
+- Public proof: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/proof.html
+- Builder guide: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/INTEGRATIONS.md
+- Releases: https://github.com/xiaojiou176-open/apple-notes-forensics/releases
 
 ## Best-fit hosts
 
 - OpenHands/extensions contribution flow
 - ClawHub-style skill publication
 - repo-local skill import flows that expect a standalone folder
+- any MCP-aware host that can launch a local stdio server on one explicit case
+  root
 
 ## What this packet must not claim
 

--- a/public-skills/notestorelab-case-review/SKILL.md
+++ b/public-skills/notestorelab-case-review/SKILL.md
@@ -1,12 +1,26 @@
 ---
 name: notestorelab-case-review
-description: Guide one bounded NoteStore Lab case review without turning the repo into a hosted platform.
+description: This skill should be used when the user asks to "review an Apple Notes case root", "set up NoteStore Lab MCP", "run notes-recovery-mcp", "ask one bounded question about a case", or "compare two NoteStore Lab case roots". It teaches install, first-success proof, and bounded case review without turning the repo into a hosted platform.
+triggers:
+  - apple notes recovery
+  - notes-recovery-mcp
+  - review_index
+  - ask-case
+  - case-diff
 ---
 
 # NoteStore Lab Case Review
 
-Use this skill when an agent is reviewing one NoteStore Lab case root or the
-public-safe demo surface.
+Use this skill when an agent needs to install, wire, or operate the NoteStore
+Lab review flow on one explicit case root or the public-safe demo surface.
+
+## What this skill teaches
+
+- how to prove the workflow shape on demo artifacts first
+- how to wire the local stdio MCP surface without pretending there is a hosted
+  service
+- how to inspect one case root at a time using derived artifacts first
+- how to ask bounded, evidence-backed questions instead of free-form guessing
 
 ## Product truth
 
@@ -16,6 +30,19 @@ public-safe demo surface.
 - Prefer derived artifacts before raw copied evidence.
 - Do not treat the live Notes store as a target.
 - Do not describe this repo as a hosted or multi-tenant platform.
+
+## First-success flow
+
+1. Install or launch the shipped surface using `references/install-and-mcp.md`.
+2. Run the public-safe proof path:
+   - `notes-recovery demo`
+   - `notes-recovery ai-review --demo`
+   - `notes-recovery ask-case --demo --question "What should I inspect first?"`
+   - `notes-recovery doctor`
+3. Only after the demo path works, point the MCP server at one explicit
+   `Notes_Forensics_<run_ts>` case root.
+4. Keep all reasoning on copied evidence and derived artifacts, not on the live
+   Notes store.
 
 ## Preferred evidence order
 
@@ -31,12 +58,12 @@ public-safe demo surface.
 notes-recovery-mcp --case-dir ./output/Notes_Forensics_<run_ts>
 ```
 
-## Proof path
+## Example prompts
 
-1. `notes-recovery demo`
-2. `notes-recovery ai-review --demo`
-3. `notes-recovery ask-case --demo --question "What should I inspect first?"`
-4. `notes-recovery doctor`
+- "Review this NoteStore Lab case root and tell me which artifact to inspect first."
+- "Wire NoteStore Lab MCP to `./output/Notes_Forensics_2026-04-08_...` and summarize the review-safe surfaces."
+- "Compare these two case roots and tell me what changed at the manifest/review layer."
+- "Generate a public-safe export plan for this case without exposing raw copied evidence."
 
 ## Truth language
 
@@ -44,3 +71,8 @@ notes-recovery-mcp --case-dir ./output/Notes_Forensics_<run_ts>
 - Good: "local copy-first case review skill"
 - Forbidden: "officially listed skill" without fresh host-side read-back
 - Forbidden: "hosted Notes recovery platform"
+
+## Read next
+
+- `references/install-and-mcp.md`
+- `references/usage-and-proof.md`

--- a/public-skills/notestorelab-case-review/manifest.yaml
+++ b/public-skills/notestorelab-case-review/manifest.yaml
@@ -4,7 +4,7 @@ artifact: public-skill-listing-manifest
 skill:
   name: notestorelab-case-review
   display_name: NoteStore Lab Case Review
-  version: 1.0.0
+  version: 1.0.1
   entrypoint: SKILL.md
   package_shape: skill-folder
 
@@ -12,7 +12,7 @@ registry_targets:
   clawhub:
     status: ready-but-not-listed
     package_shape: skill-folder
-    submit_via: clawhub publish . --slug notestorelab-case-review --name "NoteStore Lab Case Review" --version 1.0.0 --tags apple-notes,forensics,incident-response,mcp
+    submit_via: clawhub publish . --slug notestorelab-case-review --name "NoteStore Lab Case Review" --version 1.0.1 --tags apple-notes,forensics,incident-response,mcp
   openhands-extensions:
     status: folder-ready
     package_shape: skill-folder
@@ -31,4 +31,6 @@ boundaries:
 pair_with:
   - SKILL.md
   - README.md
+  - references/install-and-mcp.md
+  - references/usage-and-proof.md
   - ../../DISTRIBUTION.md

--- a/public-skills/notestorelab-case-review/references/install-and-mcp.md
+++ b/public-skills/notestorelab-case-review/references/install-and-mcp.md
@@ -1,0 +1,74 @@
+# Install And MCP Wiring
+
+Use this reference when the agent or reviewer asks:
+
+- how do I install this?
+- what is the exact MCP command?
+- what should I point my host at?
+
+## Public package lane
+
+The current shipped package lane is PyPI:
+
+```bash
+python -m pip install apple-notes-forensics==0.1.0.post1
+```
+
+If the host supports `uvx`, the shortest MCP launch path is:
+
+```bash
+uvx --from apple-notes-forensics==0.1.0.post1 \
+  notes-recovery-mcp \
+  --case-dir ./output/Notes_Forensics_<run_ts>
+```
+
+## Source checkout lane
+
+If the user is working from a cloned repository checkout:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -e .[mcp]
+notes-recovery-mcp --case-dir ./output/Notes_Forensics_<run_ts>
+```
+
+## Generic MCP host config
+
+Use this when a host expects a `mcpServers` JSON block:
+
+```json
+{
+  "mcpServers": {
+    "notestorelab": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "apple-notes-forensics==0.1.0.post1",
+        "notes-recovery-mcp",
+        "--case-dir",
+        "./output/Notes_Forensics_<run_ts>"
+      ]
+    }
+  }
+}
+```
+
+If `uvx` is unavailable, point the host at the repo-local Python command
+instead.
+
+## Capability boundary
+
+This MCP surface is:
+
+- local
+- stdio-first
+- one explicit case root at a time
+- read-mostly
+- derived-artifact-first
+
+This MCP surface is **not**:
+
+- a hosted Notes service
+- a remote multi-tenant API
+- a write path into the live Apple Notes store

--- a/public-skills/notestorelab-case-review/references/usage-and-proof.md
+++ b/public-skills/notestorelab-case-review/references/usage-and-proof.md
@@ -1,0 +1,48 @@
+# Usage And Proof
+
+Use this reference when the reviewer asks:
+
+- what does the skill actually help an agent do?
+- how do I try it in a few minutes?
+- where is the public proof?
+
+## First-success path
+
+Run the zero-risk path in this order:
+
+```bash
+notes-recovery demo
+notes-recovery ai-review --demo
+notes-recovery ask-case --demo --question "What should I inspect first?"
+notes-recovery doctor
+```
+
+What this proves:
+
+- the repo already ships a public-safe demo surface
+- AI review is real, not hypothetical
+- bounded case Q&A is real, not hypothetical
+- the MCP lane belongs on one explicit case root
+
+## Example prompts
+
+- "Summarize the demo case and list the first two artifacts I should inspect."
+- "Use the NoteStore Lab MCP lane on this case root and tell me what proof surfaces are available."
+- "Compare case A and case B and focus on the review layer, not raw copied evidence."
+- "Generate a safe sharing plan using public-safe export."
+
+## Public proof links
+
+- Landing page: https://xiaojiou176-open.github.io/apple-notes-forensics/
+- Public proof page: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/proof.html
+- Builder guide: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/INTEGRATIONS.md
+- Distribution boundary: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/DISTRIBUTION.md
+- Releases: https://github.com/xiaojiou176-open/apple-notes-forensics/releases
+
+## Reviewer checklist
+
+If a reviewer asks "what does this skill teach?", answer in one sentence:
+
+> It teaches an agent how to install NoteStore Lab's local MCP lane, prove the
+> workflow on demo artifacts, and review one copied Apple Notes case root using
+> derived artifacts instead of the live Notes store.

--- a/scripts/release/check_skill_publish_readiness.py
+++ b/scripts/release/check_skill_publish_readiness.py
@@ -23,12 +23,11 @@ DERIVED_SKILL_PATHS = (
     Path("starter-bundles/claude-code/plugins/notestorelab/skills/notestorelab-mcp/SKILL.md"),
     Path("plugins/notestorelab-openclaw-bundle/workspace/skills/notestorelab/SKILL.md"),
     Path("starter-bundles/openclaw/workspace/skills/notestorelab/SKILL.md"),
-    Path("public-skills/notestorelab-case-review/SKILL.md"),
 )
 REPO_URL = "https://github.com/xiaojiou176-open/apple-notes-forensics"
 CANONICAL_NAME = "notestorelab-case-review"
 PUBLIC_SKILL_DIR = Path("public-skills/notestorelab-case-review")
-PUBLIC_SKILL_SEMVER = "1.0.0"
+PUBLIC_SKILL_SEMVER = "1.0.1"
 
 
 def _load_pyproject(repo_root: Path) -> dict[str, object]:
@@ -143,7 +142,7 @@ def collect_skill_publish_errors(repo_root: Path) -> list[str]:
             "schema_version: 1",
             "artifact: public-skill-listing-manifest",
             "name: notestorelab-case-review",
-            "version: 1.0.0",
+            "version: 1.0.1",
             "display_name: NoteStore Lab Case Review",
             "package_shape: skill-folder",
             "clawhub:",
@@ -154,6 +153,8 @@ def collect_skill_publish_errors(repo_root: Path) -> list[str]:
             "submit_via: submit this folder as skills/notestorelab-case-review/ in OpenHands/extensions",
             "canonical_repo_version: 0.1.0.post1",
             "official_listing_state: not-yet-listed",
+            "references/install-and-mcp.md",
+            "references/usage-and-proof.md",
         ):
             if token not in public_manifest_text:
                 errors.append(f"public skill manifest is missing required token: {token}")
@@ -164,6 +165,8 @@ def collect_skill_publish_errors(repo_root: Path) -> list[str]:
             "ClawHub-style",
             "skills/notestorelab-case-review/SKILL.md",
             "no official OpenHands/extensions listing without fresh PR/read-back",
+            "What this skill teaches an agent",
+            "Demo / proof links",
         ):
             if token not in public_readme_text:
                 errors.append(f"public skill README is missing required token: {token}")


### PR DESCRIPTION
## Summary
- upgrade the public NoteStore Lab skill packet from a thin listing card into a reusable install/use/proof package
- add references for MCP install, first-success flow, example prompts, and public proof links
- keep the ClawHub/OpenHands-facing public skill packet stronger without treating it as a hosted product claim

## Test Plan
- [x] `./.venv/bin/python scripts/release/check_skill_publish_readiness.py`

## Breaking Changes
None
