### PR TITLE
feat: deepen public skill proof surfaces

### DIFF
--- a/public-skills/notestorelab-case-review/README.md
+++ b/public-skills/notestorelab-case-review/README.md
@@ -5,13 +5,16 @@ packet for NoteStore Lab.
 
 ## What this skill teaches an agent
 
-This is not just a label for Apple Notes. It teaches an agent four concrete
+This is not just a label for Apple Notes. It teaches an agent five concrete
 things:
 
 1. how to install or launch the NoteStore Lab MCP surface
 2. how to prove the review flow on public-safe demo artifacts first
 3. how to review one copied case root without touching the live Notes store
 4. how to ask bounded questions from derived artifacts instead of guessing
+5. what the MCP lane gives a host after attach: case-root listing, manifest and
+   artifact inspection, bounded case Q&A, and bounded
+   verify/report/timeline/export workflows
 
 ## What this packet includes
 
@@ -39,6 +42,25 @@ If a reviewer wants to understand the skill quickly, use this order:
 - Public proof: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/proof.html
 - Builder guide: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/INTEGRATIONS.md
 - Releases: https://github.com/xiaojiou176-open/apple-notes-forensics/releases
+
+## Visual demo
+
+![NoteStore Lab public demo surface](https://raw.githubusercontent.com/xiaojiou176-open/apple-notes-forensics/main/assets/readme/hero-public-demo.png)
+
+- Quick visual proof: the public demo already shows the bounded review flow on
+  safe artifacts before a host ever points the MCP lane at a real copied case
+  root.
+
+## MCP capability surface
+
+- Read-only review lane:
+  `list_case_roots`, `inspect_case_manifest`, `select_case_evidence`,
+  `inspect_case_artifact`, and `ask_case`
+- Bounded workflows:
+  `run_verify`, `run_report`, `build_timeline`, and `public_safe_export`
+- Boundary:
+  one explicit case root at a time, local stdio transport, and no live Notes
+  store mutation path
 
 ## Best-fit hosts
 

--- a/public-skills/notestorelab-case-review/SKILL.md
+++ b/public-skills/notestorelab-case-review/SKILL.md
@@ -22,6 +22,15 @@ Lab review flow on one explicit case root or the public-safe demo surface.
 - how to inspect one case root at a time using derived artifacts first
 - how to ask bounded, evidence-backed questions instead of free-form guessing
 
+## MCP capability surface
+
+- read-only review surfaces: `list_case_roots`, `inspect_case_manifest`,
+  `select_case_evidence`, `inspect_case_artifact`, and `ask_case`
+- bounded workflows: `run_verify`, `run_report`, `build_timeline`, and
+  `public_safe_export`
+- one explicit case root at a time, local stdio only, with no live Notes store
+  access
+
 ## Product truth
 
 - Recovery is the main product.
@@ -29,7 +38,7 @@ Lab review flow on one explicit case root or the public-safe demo surface.
 - Stay local, copy-first, and case-root-driven.
 - Prefer derived artifacts before raw copied evidence.
 - Do not treat the live Notes store as a target.
-- Do not describe this repo as a hosted or multi-tenant platform.
+- Do not describe NoteStore Lab as a hosted or multi-tenant platform.
 
 ## First-success flow
 

--- a/public-skills/notestorelab-case-review/manifest.yaml
+++ b/public-skills/notestorelab-case-review/manifest.yaml
@@ -4,7 +4,7 @@ artifact: public-skill-listing-manifest
 skill:
   name: notestorelab-case-review
   display_name: NoteStore Lab Case Review
-  version: 1.0.1
+  version: 1.0.2
   entrypoint: SKILL.md
   package_shape: skill-folder
 
@@ -12,7 +12,7 @@ registry_targets:
   clawhub:
     status: ready-but-not-listed
     package_shape: skill-folder
-    submit_via: clawhub publish . --slug notestorelab-case-review --name "NoteStore Lab Case Review" --version 1.0.1 --tags apple-notes,forensics,incident-response,mcp
+    submit_via: clawhub publish . --slug notestorelab-case-review --name "NoteStore Lab Case Review" --version 1.0.2 --tags apple-notes,forensics,incident-response,mcp
   openhands-extensions:
     status: folder-ready
     package_shape: skill-folder

--- a/public-skills/notestorelab-case-review/references/usage-and-proof.md
+++ b/public-skills/notestorelab-case-review/references/usage-and-proof.md
@@ -24,6 +24,17 @@ What this proves:
 - bounded case Q&A is real, not hypothetical
 - the MCP lane belongs on one explicit case root
 
+## MCP capability surface after attach
+
+- Read-only review surfaces:
+  `list_case_roots`, `inspect_case_manifest`, `select_case_evidence`,
+  `inspect_case_artifact`, and `ask_case`
+- Bounded workflows:
+  `run_verify`, `run_report`, `build_timeline`, and `public_safe_export`
+- Boundary:
+  local stdio only, one explicit case root at a time, and no live Notes store
+  access
+
 ## Example prompts
 
 - "Summarize the demo case and list the first two artifacts I should inspect."
@@ -38,6 +49,10 @@ What this proves:
 - Builder guide: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/INTEGRATIONS.md
 - Distribution boundary: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/DISTRIBUTION.md
 - Releases: https://github.com/xiaojiou176-open/apple-notes-forensics/releases
+
+## Visual demo
+
+![NoteStore Lab demo screenshot](https://raw.githubusercontent.com/xiaojiou176-open/apple-notes-forensics/main/assets/readme/hero-public-demo.png)
 
 ## Reviewer checklist
 

--- a/scripts/release/check_skill_publish_readiness.py
+++ b/scripts/release/check_skill_publish_readiness.py
@@ -27,7 +27,7 @@ DERIVED_SKILL_PATHS = (
 REPO_URL = "https://github.com/xiaojiou176-open/apple-notes-forensics"
 CANONICAL_NAME = "notestorelab-case-review"
 PUBLIC_SKILL_DIR = Path("public-skills/notestorelab-case-review")
-PUBLIC_SKILL_SEMVER = "1.0.1"
+PUBLIC_SKILL_SEMVER = "1.0.2"
 
 
 def _load_pyproject(repo_root: Path) -> dict[str, object]:
@@ -142,7 +142,7 @@ def collect_skill_publish_errors(repo_root: Path) -> list[str]:
             "schema_version: 1",
             "artifact: public-skill-listing-manifest",
             "name: notestorelab-case-review",
-            "version: 1.0.1",
+            "version: 1.0.2",
             "display_name: NoteStore Lab Case Review",
             "package_shape: skill-folder",
             "clawhub:",


### PR DESCRIPTION
## Summary
- strengthen the public NoteStore Lab skill packet with explicit MCP capability surface guidance
- add visual demo links so reviewers can see the proof path faster
- bump the ClawHub-facing public skill packet to 1.0.2 and keep release-readiness checks aligned

## Verification
- `python3 scripts/release/check_skill_publish_readiness.py`