### PR TITLE
fix: align forensics public truth and CI contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 8 * * *"
 
 permissions:
   actions: read
@@ -35,11 +38,29 @@ jobs:
             tests/test_case_contract.py \
             tests/test_handlers_commands.py \
             tests/test_auto_run_full.py \
+            tests/test_verify.py \
+            -q
+
+  deep-realism:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: pip install -e .[dev]
+      - name: Deep realism smoke
+        run: |
+          python -m pytest \
             tests/test_realistic_flow_e2e.py \
             tests/test_timeline_integration.py \
             tests/test_spotlight_deep.py \
             tests/test_fts_index_build.py \
-            tests/test_verify.py \
             -q
 
   extras-ai-mcp:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,7 +240,7 @@ Use this layer map when you decide where a check belongs:
 | `pre-commit` | every local commit attempt | fast local static gates, hygiene, docs/public-surface drift guards, and host-safety checks |
 | `pre-push` | before pushing a branch | local baseline smoke on the core recovery path, plus commit-history identity checks |
 | `hosted` | GitHub Actions on `push` / `pull_request` | required matrix jobs, repo-hygiene/security scans, optional-surface smoke, and deterministic distribution build-readiness |
-| `nightly` | scheduled GitHub Actions | non-required deep analysis that is useful over time but too heavy or too platform-bound for the default push path |
+| `nightly` | scheduled GitHub Actions and manual dispatch | non-required deep analysis that is useful over time but too heavy or too platform-bound for the default pull-request fast lane |
 | `manual` | maintainer-triggered or owner-side | live GitHub settings/storefront checks, registry/marketplace submission, PyPI publish, and final release-readiness acceptance |
 
 Keep remote GitHub-state checks and publication checks out of the default local
@@ -261,10 +261,6 @@ grep -q "NoteStore Lab public demo" "$tmp"
   tests/test_case_contract.py \
   tests/test_handlers_commands.py \
   tests/test_auto_run_full.py \
-  tests/test_realistic_flow_e2e.py \
-  tests/test_timeline_integration.py \
-  tests/test_spotlight_deep.py \
-  tests/test_fts_index_build.py \
   tests/test_verify.py \
   -q
 ```
@@ -274,6 +270,31 @@ That baseline contract is intentionally narrow:
 - `notes-recovery --help` proves the installed CLI entrypoint resolves
 - `notes-recovery demo` proves the public-safe first-look path is non-empty
 - the canonical smoke test list proves the core `.[dev]` pipeline still holds
+
+Treat the `baseline` job name as the merge-critical first-success lane. It is
+the fast PR gate, not the place for longer realism or indexing checks.
+
+The workflow also keeps a dedicated **deep realism** lane for the slower paths
+that still matter after merge:
+
+- it runs on pushes to `main`
+- it is available through scheduled/nightly automation
+- it is available through manual dispatch when you want the deeper path on demand
+
+The workflow keeps the existing required-check names stable for branch-protection
+compatibility. Jobs such as `extras-dashboard` remain separate compatibility
+contexts; they do not redefine what the baseline contract means.
+
+Deep realism smoke:
+
+```bash
+.venv/bin/python -m pytest \
+  tests/test_realistic_flow_e2e.py \
+  tests/test_timeline_integration.py \
+  tests/test_spotlight_deep.py \
+  tests/test_fts_index_build.py \
+  -q
+```
 
 Run optional smoke checks only when you touch those areas.
 
@@ -528,6 +549,11 @@ contexts exposed by the canonical GitHub repository:
 - `repo-hygiene`
 - `local-guardrails`
 - `open-source-boundary`
+
+Only `baseline` is the merge-critical first-success lane. The remaining
+required-check compatibility contexts stay split so the repository can keep the
+current GitHub branch-protection names stable without pretending optional
+surfaces are part of the baseline smoke contract.
 
 CodeQL is still part of the repository's security posture, but it remains a
 non-required analysis lane in the current branch-protection contract. Keep it

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -17,11 +17,11 @@ Use it when you need to answer:
 
 | Surface | Official public surface exists | Repo-owned artifact shipped | Wave 1 posture | Current truthful boundary |
 | --- | --- | --- | --- | --- |
-| MCP Registry | yes, the official MCP Registry exists and is still documented as a preview surface | yes: `server.json` and `notes-recovery-mcp` | current pure-MCP companion lane | keep the front door on the local case-root workflow; treat package/registry read-back as later validation instead of the first claim a reviewer sees |
+| MCP Registry | yes, the official MCP Registry exists and is still documented as a preview surface | yes: `server.json` and `notes-recovery-mcp` | current pure-MCP companion lane | fresh registry read-back exists for the current package lane, but keep the front door on the local case-root workflow instead of leading with registry status |
 | Codex | yes, the official Codex plugin directory exists, but third-party official-directory submission is still coming soon | yes: `plugins/notestorelab-codex-plugin/` | companion plugin lane | repo-owned Codex bundle shipped; do not claim official Codex directory listing |
 | Claude Code | yes, official plugin and marketplace surfaces exist | yes: `plugins/notestorelab-claude-plugin/` plus root `.claude-plugin/marketplace.json` | companion plugin lane | repo-owned Claude plugin and marketplace metadata shipped; do not claim Anthropic-managed listing without fresh read-back |
-| OpenClaw | yes, the official ClawHub public registry exists | yes: `plugins/notestorelab-openclaw-bundle/` | comparison-path companion lane | compatible bundle shipped in-repo; do not claim live ClawHub or official OpenClaw listing |
-| OpenHands/extensions | yes, the official OpenHands public extensions registry exists | yes: `public-skills/notestorelab-case-review/` plus canonical `skills/notestorelab-case-review/` | portable public skill lane | public skill folder shipped; do not claim a live OpenHands/extensions listing without fresh PR/read-back |
+| OpenClaw | yes, the official ClawHub public registry exists | yes: `plugins/notestorelab-openclaw-bundle/` | comparison-path companion lane | the secondary ClawHub public-skill listing is live, but the shipped OpenClaw-compatible bundle still does not prove an official OpenClaw listing or first-class host wrapper acceptance |
+| OpenHands/extensions | yes, the official OpenHands public extensions registry exists | yes: `public-skills/notestorelab-case-review/` plus canonical `skills/notestorelab-case-review/` | portable public skill lane | public skill folder shipped; the current thread is submission-done plus changes-requested, so do not claim a live OpenHands/extensions listing until maintainer acceptance lands |
 | Glama | yes, the public Add Server and hosted MCP surface exists | yes: `glama.json`, `Dockerfile`, and the canonical GHCR target | Wave 2 metadata prep | repo-owned Glama metadata and Docker-facing inputs shipped; do not claim a live Glama listing without fresh Glama-side read-back |
 | Docker MCP Catalog | yes, the official curated Docker MCP Catalog exists | yes: `Dockerfile`, `scripts/release/check_docker_surface.py`, and the canonical GHCR target | Wave 2 container/catalog prep | Docker-facing container inputs shipped; do not claim a live Docker catalog listing without fresh Docker-side submission/read-back |
 
@@ -72,6 +72,8 @@ That packet is intentionally separate from the canonical skill SSOT:
   publication
 - the public packet adds an OpenHands/extensions-facing README so external
   reviewers do not need to infer the install story from internal bundle paths
+- today that packet already has a live secondary ClawHub listing, while the
+  OpenHands submission still remains in platform review
 
 ## Package Surface
 
@@ -82,8 +84,9 @@ The canonical installable package surface for this repository is PyPI:
   story is Python-first
 - this is the intended PyPI package identifier and version for the current repo
   contract: `apple-notes-forensics==0.1.0.post1`
-- later package read-back belongs in Wave 2 validation, not in the front-door
-  product sentence
+- fresh package read-back exists for this package lane, but keep package status
+  as supporting distribution truth rather than the first sentence of the
+  product story
 
 There is no tracked npm package surface in the current public contract:
 
@@ -145,10 +148,10 @@ claude plugin validate .
 
 ### MCP Registry descriptor boundary
 
-`server.json` is the metadata side of the MCP Registry story. In Wave 1, keep
-the repo-side claim narrow: the stdio-first MCP descriptor is shipped in-repo,
-and later registry/package read-back belongs in a fresh validation pass before
-you call anything live or listed.
+`server.json` is the metadata side of the MCP Registry story. Keep the
+repo-side claim narrow: the stdio-first MCP descriptor is shipped in-repo, and
+fresh registry/package read-back supports that lane without replacing the
+copy-first front-door story.
 
 The repo-side publish-readiness proof command is:
 
@@ -175,7 +178,7 @@ The repo-side publish-readiness proof command is:
 - "registry metadata proves MCP Registry listing" without fresh registry read-back
 - "official Codex plugin directory listing" without OpenAI-managed listing proof
 - "official Anthropic marketplace listing" without fresh marketplace read-back
-- "live ClawHub listing" without fresh OpenClaw-side listing proof
+- "live OpenClaw bundle listing" without fresh OpenClaw-side acceptance proof
 - "live OpenHands/extensions listing" without fresh OpenHands PR/read-back
 - "official npm package" or "npm is the canonical install path" without a real shipped npm package surface
 - "host-side accepted skill" without fresh host-side read-back

--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -140,9 +140,9 @@ registry listings.
 
 For the MCP lane specifically, `server.json` is still the repo-owned metadata
 layer around the same local stdio workflow. Keep the repo-side claim narrow
-here: the package/install surface is real, but package read-back, registry
-read-back, and host-side submission state belong in a fresh later-lane
-validation pass before you call anything live or listed. Use
+here: the package/install surface is real, and fresh package/registry
+read-back now exists for the current MCP and PyPI lane, but this guide still
+keeps that supporting truth behind the local case-root story. Use
 [DISTRIBUTION.md](./DISTRIBUTION.md) when you need the current package,
 registry, or listing boundary.
 
@@ -162,7 +162,7 @@ OpenClaw-style install path:
 
 - Build the OpenClaw-compatible archive with `build_distribution_bundles.py`.
 - Install the local archive with `openclaw plugins install ./dist/notestorelab-openclaw-bundle-v0.1.0.zip`.
-- Treat ClawHub publication as a later manual external step, not as a repo-side done claim.
+- A live ClawHub public-skill listing now exists for the secondary packet lane, but that does not turn this OpenClaw-compatible bundle into a live OpenClaw bundle listing.
 
 Current design intent:
 
@@ -177,9 +177,9 @@ Current design intent:
 | --- | --- | --- |
 | Codex plugin bundle | shipped | use `plugins/notestorelab-codex-plugin/` and a real local marketplace entry |
 | Claude Code marketplace-format starter | shipped | use `.claude-plugin/marketplace.json` plus `plugins/notestorelab-claude-plugin/` without turning it into proof of an Anthropic-managed listing |
-| OpenClaw-compatible bundle | shipped | build the local archive from `plugins/notestorelab-openclaw-bundle/`; do not claim a live ClawHub listing yet |
+| OpenClaw-compatible bundle | shipped | build the local archive from `plugins/notestorelab-openclaw-bundle/`; the secondary ClawHub public-skill listing is live, but it does not prove a live OpenClaw bundle listing |
 | canonical independent skill surface | shipped | use `skills/notestorelab-case-review/` as the canonical independent skill surface; plugin/starter skill files are host-specific derived copies |
-| OpenHands/extensions-friendly public skill folder | shipped | use `public-skills/notestorelab-case-review/` when you need a standalone skill-folder packet for OpenHands/extensions or similar registries |
+| OpenHands/extensions-friendly public skill folder | shipped | use `public-skills/notestorelab-case-review/` when you need a standalone skill-folder packet for OpenHands/extensions or similar registries; today the same packet is live on ClawHub while the OpenHands thread remains changes-requested |
 | repo-owned host plugin | shipped as installable bundles | the shipped plugins are installable surfaces, but installability does not imply official listing |
 
 ## Container Later Surface

--- a/README.md
+++ b/README.md
@@ -72,12 +72,17 @@ Fast route map if you do not want to guess:
 - **Primary extension**: `notes-recovery-mcp` as the repo's `pure_mcp` review
   surface
 - **Secondary**: `public-skills/notestorelab-case-review/` as the standalone
-  `pure_skills` packet for host-native reviewers
-- **Later / companion**: plugin bundles, PyPI or registry proof, Docker/GHCR,
-  and Glama metadata after the local case path already makes sense
+  `pure_skills` packet for host-native reviewers; its secondary ClawHub packet
+  listing is live, but it still stays behind the landing/proof route
+- **Later / companion**: plugin bundles, deeper package/registry detail,
+  Docker/GHCR, and Glama metadata after the local case path already makes
+  sense
 - **Current non-claims**: no hosted Notes recovery service, no multi-tenant
-  review portal, and no live ClawHub/OpenHands/extensions/Glama/Docker catalog
-  listing language in Wave 1
+  review portal, and no live OpenHands/extensions/Glama/Docker catalog listing
+  language in the front-door sentence
+- **Current review tail**: OpenHands/extensions is submission-done with
+  changes requested, so keep that lane in platform review until a live
+  read-back exists
 
 Deep reads once the first path makes sense:
 [LLMs Guide](./llms.txt) · [Distribution](./DISTRIBUTION.md) ·
@@ -530,6 +535,9 @@ Right now:
 - a public-safe demo is available in this repository
 - the GitHub Release page and the GitHub Pages landing are the main public
   proof surfaces around the repo
+- fresh distribution read-back exists for the MCP package lane, the PyPI
+  package lane, and the secondary ClawHub skill packet; keep those as support
+  receipts instead of the first sentence a new reviewer sees
 - `llms.txt`, `robots.txt`, and `sitemap.xml` now expose the current public contract to AI crawlers and search engines without pretending the repo is an API platform
 - GitHub description, topics, and custom social preview status should be treated
   as GitHub Settings items, not repository facts

--- a/index.html
+++ b/index.html
@@ -815,9 +815,9 @@
               <p>Manifests, summaries, verification previews, and reports remain the center of gravity.</p>
             </div>
             <div class="proof-rail-links">
+              <a class="pill" href="proof.html">Public proof</a>
               <a class="pill" href="https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/USE_CASES.md">Use cases</a>
               <a class="pill" href="llms.txt">LLMs guide</a>
-              <a class="pill" href="https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/INTEGRATIONS.md">Builder guide</a>
             </div>
           </div>
         </div>
@@ -881,7 +881,7 @@
             <p>Use the use-case map when you need to separate operator review, AI triage, MCP consumption, and case comparison.</p>
             <div class="proof-rail-links">
               <a class="pill" href="https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/USE_CASES.md">Open use cases</a>
-              <a class="pill" href="https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/README.md#what-you-can-prove-today">Open proof table</a>
+              <a class="pill" href="proof.html">Open public proof</a>
             </div>
           </article>
           <article class="grid-card">
@@ -895,7 +895,7 @@
         </div>
       </section>
 
-      <section class="section">
+      <section class="section" id="truth-surface">
         <div class="section-head">
           <div>
             <div class="section-kicker">Curation</div>
@@ -1072,8 +1072,9 @@
         </div>
         <div class="note">
           OpenClaw-style hosts stay in the comparison bucket for now. This repo
-          now ships an OpenClaw-compatible bundle build path, but not a live
-          ClawHub listing or a first-class host-specific contract.
+          now ships an OpenClaw-compatible bundle build path. The secondary
+          ClawHub skill listing is live, but that still does not create a
+          first-class OpenClaw host contract.
         </div>
         <div class="wrapper-grid">
           <article class="snippet-card">
@@ -1129,7 +1130,7 @@ cwd = ".."</code></pre>
             </tr>
             <tr>
               <th>OpenClaw-style hosts</th>
-              <td>Compatible bundle path now shipped. Reuse the same local MCP command and the bundled archive build, but do not claim a live ClawHub listing or first-class wrapper without fresh external read-back.</td>
+              <td>Compatible bundle path now shipped. Reuse the same local MCP command and the bundled archive build, but do not treat the live secondary ClawHub skill listing as proof of a first-class OpenClaw wrapper or bundle listing.</td>
             </tr>
           </tbody>
         </table>

--- a/proof.html
+++ b/proof.html
@@ -332,16 +332,16 @@ notes-recovery doctor</code></pre>
             <p>GitHub repository is public, points at the current Pages landing, and keeps the current product description aligned with the copy-first story.</p>
           </div>
           <div class="card remote-card">
-            <strong>Release read-back</strong>
-            <p>Release <code>v0.1.0</code> exists and remains the current published tag tied to the local git tag.</p>
+            <strong>Package and registry read-back</strong>
+            <p>Fresh read-back exists for the PyPI package lane and the official MCP Registry entry that backs the current stdio-first MCP surface.</p>
           </div>
           <div class="card remote-card">
-            <strong>Pages read-back</strong>
-            <p>GitHub Pages is built from <code>main:/</code>, which keeps the landing and proof pages on the repo-owned surface.</p>
+            <strong>Secondary packet listing</strong>
+            <p>The standalone public skill packet is live on ClawHub as a secondary lane. That supports discovery, but it does not replace the landing-first copy-first story.</p>
           </div>
           <div class="card remote-card">
-            <strong>Security read-back</strong>
-            <p>Secret scanning alerts are readable and expected to stay at zero. Release readiness continues to audit the same remote truth.</p>
+            <strong>OpenHands review thread</strong>
+            <p>The OpenHands/extensions submission exists, but the current thread is still open with changes requested. Treat it as submission-done and platform-not-accepted-yet, not live.</p>
           </div>
         </div>
       </section>
@@ -383,9 +383,10 @@ notes-recovery doctor</code></pre>
         </div>
         <ul>
           <li><a href="README.md">README</a>: first meeting and quickstart</li>
+          <li><a href="https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/USE_CASES.md">Use Cases</a>: choose the operator, AI review, MCP, or compare lane before you open builder notes</li>
           <li><a href="llms.txt">llms.txt</a>: fastest truthful machine-readable summary</li>
-          <li><a href="https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/INTEGRATIONS.md">Builder Guide</a>: MCP and host integration lane</li>
-          <li><a href="https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/DISTRIBUTION.md">Distribution Surface</a>: listing boundary and shipped bundles</li>
+          <li><a href="https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/INTEGRATIONS.md">Builder Guide</a>: raw builder and host integration references after the proof path</li>
+          <li><a href="https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/DISTRIBUTION.md">Distribution Surface</a>: exact listing boundary and shipped-bundle ledger after the proof path</li>
           <li><a href="https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/SUPPORT.md">Support</a>: issue/reporting contract</li>
         </ul>
       </section>

--- a/public-skills/notestorelab-case-review/README.md
+++ b/public-skills/notestorelab-case-review/README.md
@@ -8,6 +8,11 @@ its explicit-case-root MCP surface. This packet exists so a host-native
 reviewer can learn that workflow without turning the repo into a hosted service
 or a plugin/store product pitch.
 
+Today the secondary ClawHub packet listing is live, while the
+OpenHands/extensions submission still sits in a changes-requested review state.
+That means this packet can point to a real public listing without pretending
+the OpenHands lane is already accepted or live.
+
 ## What this skill teaches an agent
 
 This is not just a label for Apple Notes. It teaches an agent five concrete
@@ -49,13 +54,20 @@ If a reviewer wants to understand the skill quickly, use this order:
 1. read `SKILL.md`
 2. open `references/INSTALL.md`
 3. run the public-safe proof path from `references/DEMO.md`
-4. inspect the public proof links before claiming any host-side acceptance
+4. walk `Landing -> Public Proof -> Use Cases` before opening builder or raw-source references
 
 ## Demo / proof links
 
+Primary reviewer route:
+
 - Landing: https://xiaojiou176-open.github.io/apple-notes-forensics/
-- Public proof: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/proof.html
+- Public proof: https://xiaojiou176-open.github.io/apple-notes-forensics/proof.html
+- Use cases: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/USE_CASES.md
+
+Builder / raw-source references after the route above:
+
 - Builder guide: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/INTEGRATIONS.md
+- Distribution boundary: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/DISTRIBUTION.md
 - Releases: https://github.com/xiaojiou176-open/apple-notes-forensics/releases
 
 ## Visual demo
@@ -89,7 +101,8 @@ If a reviewer wants to understand the skill quickly, use this order:
 
 - no flagship plugin/store lane for the overall product
 - no official OpenHands/extensions listing without fresh PR/read-back
-- no live ClawHub listing without fresh host-side read-back
+- no accepted OpenHands/extensions host lane just because a submission already exists
+- no first-class OpenClaw bundle listing or host-wrapper acceptance just because the secondary ClawHub skill listing is live
 - no hosted Glama deployment, Docker catalog listing, or remote MCP lane
 - no direct mutation of the live Apple Notes store
 

--- a/public-skills/notestorelab-case-review/manifest.yaml
+++ b/public-skills/notestorelab-case-review/manifest.yaml
@@ -10,20 +10,23 @@ skill:
 
 registry_targets:
   clawhub:
-    status: ready-but-not-listed
+    status: listed-live
+    live_read_back: https://clawhub.ai/xiaojiou176/notestorelab-case-review
     package_shape: skill-folder
     submit_via: clawhub publish . --slug notestorelab-case-review --name "NoteStore Lab Case Review" --version 1.0.2 --tags apple-notes,forensics,incident-response,mcp
   openhands-extensions:
-    status: folder-ready
+    status: submission-done-platform-not-accepted-yet
+    review_state: changes-requested
     package_shape: skill-folder
     submit_via: submit this folder as skills/notestorelab-case-review/ in OpenHands/extensions
 
 boundaries:
   product_identity: Copy-first Apple Notes case review skill for NoteStore Lab.
   canonical_repo_version: 0.1.0.post1
-  official_listing_state: not-yet-listed
+  official_listing_state: clawhub-listed-live-openhands-submission-done
+  confirmed_live:
+    - ClawHub public skill listing is live at https://clawhub.ai/xiaojiou176/notestorelab-case-review
   not_claimed:
-    - No live ClawHub listing exists yet
     - No live OpenHands/extensions listing exists yet
     - No hosted Glama deployment exists yet
     - No live Docker MCP Catalog listing exists yet

--- a/public-skills/notestorelab-case-review/references/DEMO.md
+++ b/public-skills/notestorelab-case-review/references/DEMO.md
@@ -17,8 +17,20 @@ notes-recovery doctor
 
 ## Public proof links
 
+Primary reviewer route:
+
 - Landing page: https://xiaojiou176-open.github.io/apple-notes-forensics/
-- Public proof page: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/proof.html
+- Public proof page: https://xiaojiou176-open.github.io/apple-notes-forensics/proof.html
+- Use cases: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/USE_CASES.md
+
+Builder / raw-source references after the route above:
+
 - Builder guide: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/INTEGRATIONS.md
 - Distribution boundary: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/DISTRIBUTION.md
 - Releases: https://github.com/xiaojiou176-open/apple-notes-forensics/releases
+
+Today truth:
+
+- the secondary ClawHub packet listing is live
+- the OpenHands/extensions lane is still submission-done plus changes-requested,
+  so it is not an accepted/live host listing yet

--- a/scripts/ci/check_verification_contract.py
+++ b/scripts/ci/check_verification_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -8,9 +9,11 @@ try:
         BASELINE_DEMO_COMMAND,
         BASELINE_DOC_COMMAND,
         BASELINE_TESTS,
+        CONTRIBUTING_VERIFICATION_REQUIRED_TOKENS,
+        DEEP_REALISM_JOB_NAME,
+        DEEP_REALISM_TESTS,
         FULL_SUITE_DOC_COMMAND,
         README_VERIFICATION_REQUIRED_TOKENS,
-        VERIFICATION_SUMMARY_TOKENS,
         WORKFLOW_DEMO_COMMAND,
         WORKFLOW_HELP_COMMAND,
     )
@@ -19,9 +22,11 @@ except ModuleNotFoundError:  # pragma: no cover - direct script execution fallba
         BASELINE_DEMO_COMMAND,
         BASELINE_DOC_COMMAND,
         BASELINE_TESTS,
+        CONTRIBUTING_VERIFICATION_REQUIRED_TOKENS,
+        DEEP_REALISM_JOB_NAME,
+        DEEP_REALISM_TESTS,
         FULL_SUITE_DOC_COMMAND,
         README_VERIFICATION_REQUIRED_TOKENS,
-        VERIFICATION_SUMMARY_TOKENS,
         WORKFLOW_DEMO_COMMAND,
         WORKFLOW_HELP_COMMAND,
     )
@@ -38,6 +43,16 @@ FORBIDDEN_BASELINE_LINES = (
 )
 
 
+def _extract_job_block(workflow_text: str, job_name: str) -> str | None:
+    match = re.search(
+        rf"(?ms)^  {re.escape(job_name)}:\n(.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+        workflow_text,
+    )
+    if match is None:
+        return None
+    return match.group(0)
+
+
 def _read(repo_root: Path, rel_path: str) -> str | None:
     path = repo_root / rel_path
     if not path.exists():
@@ -52,14 +67,43 @@ def collect_verification_contract_errors(repo_root: Path) -> list[str]:
     if workflow_text is None:
         return ["missing .github/workflows/ci.yml"]
 
-    if WORKFLOW_HELP_COMMAND not in workflow_text:
+    baseline_block = _extract_job_block(workflow_text, "baseline")
+    if baseline_block is None:
+        errors.append("workflow is missing the baseline job block")
+        baseline_block = workflow_text
+
+    if WORKFLOW_HELP_COMMAND not in baseline_block:
         errors.append("workflow baseline is missing the CLI help command")
-    if WORKFLOW_DEMO_COMMAND not in workflow_text:
+    if WORKFLOW_DEMO_COMMAND not in baseline_block:
         errors.append("workflow baseline is missing the public demo command")
 
     for test_path in BASELINE_TESTS:
-        if test_path not in workflow_text:
+        if test_path not in baseline_block:
             errors.append(f"workflow baseline is missing canonical smoke test: {test_path}")
+
+    for test_path in DEEP_REALISM_TESTS:
+        if test_path in baseline_block:
+            errors.append(
+                f"workflow baseline must not include deep realism test: {test_path}"
+            )
+
+    deep_realism_block = _extract_job_block(workflow_text, DEEP_REALISM_JOB_NAME)
+    if deep_realism_block is None:
+        errors.append(
+            f"workflow is missing the `{DEEP_REALISM_JOB_NAME}` job for deeper-path verification"
+        )
+    else:
+        for test_path in DEEP_REALISM_TESTS:
+            if test_path not in deep_realism_block:
+                errors.append(
+                    f"`{DEEP_REALISM_JOB_NAME}` is missing deep realism test: {test_path}"
+                )
+
+    for trigger in ("schedule:", "workflow_dispatch:"):
+        if trigger not in workflow_text:
+            errors.append(
+                f"workflow must expose `{DEEP_REALISM_JOB_NAME}` through `{trigger}`"
+            )
 
     readme_text = _read(repo_root, "README.md")
     if readme_text is None:
@@ -93,13 +137,16 @@ def collect_verification_contract_errors(repo_root: Path) -> list[str]:
             if forbidden in stripped_lines:
                 errors.append(f"CONTRIBUTING.md must not claim `{forbidden}` as the baseline contract")
 
-        for token in VERIFICATION_SUMMARY_TOKENS:
+        for token in CONTRIBUTING_VERIFICATION_REQUIRED_TOKENS:
             if token not in lowered:
                 errors.append(f"CONTRIBUTING.md is missing verification contract token: {token}")
 
         for test_path in BASELINE_TESTS:
             if test_path not in contributing_text:
                 errors.append(f"CONTRIBUTING.md is missing canonical smoke test: {test_path}")
+        for test_path in DEEP_REALISM_TESTS:
+            if test_path not in contributing_text:
+                errors.append(f"CONTRIBUTING.md is missing deep realism test: {test_path}")
         if FULL_SUITE_DOC_COMMAND not in contributing_text:
             errors.append("CONTRIBUTING.md should document the broader full suite sweep explicitly")
 

--- a/scripts/ci/contracts.py
+++ b/scripts/ci/contracts.py
@@ -31,6 +31,7 @@ BASELINE_DEMO_COMMAND = ".venv/bin/notes-recovery demo"
 FULL_SUITE_DOC_COMMAND = ".venv/bin/python -m pytest tests/ -q"
 WORKFLOW_HELP_COMMAND = "notes-recovery --help"
 WORKFLOW_DEMO_COMMAND = "notes-recovery demo"
+DEEP_REALISM_JOB_NAME = "deep-realism"
 
 BASELINE_TESTS = (
     "tests/test_cli_entrypoints.py",
@@ -39,17 +40,26 @@ BASELINE_TESTS = (
     "tests/test_case_contract.py",
     "tests/test_handlers_commands.py",
     "tests/test_auto_run_full.py",
+    "tests/test_verify.py",
+)
+
+DEEP_REALISM_TESTS = (
     "tests/test_realistic_flow_e2e.py",
     "tests/test_timeline_integration.py",
     "tests/test_spotlight_deep.py",
     "tests/test_fts_index_build.py",
-    "tests/test_verify.py",
 )
 
 VERIFICATION_SUMMARY_TOKENS = (
     "baseline smoke",
     "full suite",
     "optional surfaces",
+)
+
+CONTRIBUTING_VERIFICATION_REQUIRED_TOKENS = (
+    *VERIFICATION_SUMMARY_TOKENS,
+    "deep realism",
+    "required-check compatibility",
 )
 
 README_VERIFICATION_REQUIRED_TOKENS = (

--- a/scripts/release/check_skill_publish_readiness.py
+++ b/scripts/release/check_skill_publish_readiness.py
@@ -32,6 +32,7 @@ LEGACY_PUBLIC_REFERENCE_FILES = (
     PUBLIC_SKILL_DIR / "references" / "install-and-mcp.md",
     PUBLIC_SKILL_DIR / "references" / "usage-and-proof.md",
 )
+PUBLIC_SKILL_DEMO_PATH = PUBLIC_SKILL_DIR / "references" / "DEMO.md"
 
 
 def _load_pyproject(repo_root: Path) -> dict[str, object]:
@@ -134,12 +135,15 @@ def collect_skill_publish_errors(repo_root: Path) -> list[str]:
     public_skill_dir = repo_root / PUBLIC_SKILL_DIR
     public_skill_manifest = public_skill_dir / "manifest.yaml"
     public_skill_readme = public_skill_dir / "README.md"
+    public_skill_demo = repo_root / PUBLIC_SKILL_DEMO_PATH
     if not public_skill_dir.exists():
         errors.append(f"missing public skill directory: {PUBLIC_SKILL_DIR}")
     if not public_skill_manifest.exists():
         errors.append(f"missing public skill manifest: {public_skill_manifest.relative_to(repo_root)}")
     if not public_skill_readme.exists():
         errors.append(f"missing public skill README: {public_skill_readme.relative_to(repo_root)}")
+    if not public_skill_demo.exists():
+        errors.append(f"missing public skill demo reference: {public_skill_demo.relative_to(repo_root)}")
     if public_skill_manifest.exists():
         public_manifest_text = public_skill_manifest.read_text(encoding="utf-8")
         for token in (
@@ -151,12 +155,16 @@ def collect_skill_publish_errors(repo_root: Path) -> list[str]:
             "package_shape: skill-folder",
             "clawhub:",
             "openhands-extensions:",
-            "status: ready-but-not-listed",
-            "status: folder-ready",
+            "status: listed-live",
+            "live_read_back: https://clawhub.ai/xiaojiou176/notestorelab-case-review",
+            "status: submission-done-platform-not-accepted-yet",
+            "review_state: changes-requested",
             "submit_via: clawhub publish .",
             "submit_via: submit this folder as skills/notestorelab-case-review/ in OpenHands/extensions",
             "canonical_repo_version: 0.1.0.post1",
-            "official_listing_state: not-yet-listed",
+            "official_listing_state: clawhub-listed-live-openhands-submission-done",
+            "confirmed_live:",
+            "ClawHub public skill listing is live at https://clawhub.ai/xiaojiou176/notestorelab-case-review",
             "references/README.md",
             "references/INSTALL.md",
             "references/OPENHANDS_MCP_CONFIG.json",
@@ -174,11 +182,38 @@ def collect_skill_publish_errors(repo_root: Path) -> list[str]:
             "ClawHub-style",
             "skills/notestorelab-case-review/SKILL.md",
             "no official OpenHands/extensions listing without fresh PR/read-back",
+            "Today the secondary ClawHub packet listing is live",
+            "OpenHands/extensions submission still sits in a changes-requested review state",
             "What this skill teaches an agent",
+            "Primary reviewer route:",
+            "Use cases: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/USE_CASES.md",
+            "Builder / raw-source references after the route above:",
             "Demo / proof links",
         ):
             if token not in public_readme_text:
                 errors.append(f"public skill README is missing required token: {token}")
+        for token in (
+            "no live ClawHub listing without fresh host-side read-back",
+        ):
+            if token in public_readme_text:
+                errors.append(f"public skill README still contains stale ClawHub wording: {token}")
+    if public_skill_demo.exists():
+        public_demo_text = public_skill_demo.read_text(encoding="utf-8")
+        for token in (
+            "Primary reviewer route:",
+            "Landing page: https://xiaojiou176-open.github.io/apple-notes-forensics/",
+            "Public proof page: https://xiaojiou176-open.github.io/apple-notes-forensics/proof.html",
+            "Use cases: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/USE_CASES.md",
+            "Builder / raw-source references after the route above:",
+            "the secondary ClawHub packet listing is live",
+            "submission-done plus changes-requested",
+        ):
+            if token not in public_demo_text:
+                errors.append(f"public skill demo reference is missing required token: {token}")
+        if "https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/proof.html" in public_demo_text:
+            errors.append(
+                "public skill demo reference still points first-hop proof at a blob page"
+            )
     for legacy_ref in LEGACY_PUBLIC_REFERENCE_FILES:
         if (repo_root / legacy_ref).exists():
             errors.append(f"legacy public skill reference should be removed: {legacy_ref}")
@@ -235,6 +270,19 @@ def collect_skill_publish_errors(repo_root: Path) -> list[str]:
             errors.append(f"llms.txt should not reuse stale live-claim wording: {forbidden_token}")
     if "OpenHands/extensions-ready public skill folder" not in ecosystem_text:
         errors.append("ECOSYSTEM.md must describe the OpenHands-facing public skill lane")
+    for rel_path, text in (
+        ("README.md", readme_text),
+        ("DISTRIBUTION.md", distribution_text),
+        ("INTEGRATIONS.md", integrations_text),
+    ):
+        for token in (
+            "no live ClawHub/OpenHands/extensions/Glama/Docker catalog listing language in Wave 1",
+            "do not claim live ClawHub or official OpenClaw listing",
+            "Treat ClawHub publication as a later manual external step",
+            "do not claim a live ClawHub listing yet",
+        ):
+            if token in text:
+                errors.append(f"{rel_path} still contains stale ClawHub or OpenHands wording: {token}")
 
     return errors
 

--- a/tests/test_repo_surface.py
+++ b/tests/test_repo_surface.py
@@ -4,10 +4,12 @@ from pathlib import Path
 
 from scripts.ci.contracts import (
     BASELINE_TESTS,
+    CONTRIBUTING_VERIFICATION_REQUIRED_TOKENS,
+    DEEP_REALISM_JOB_NAME,
+    DEEP_REALISM_TESTS,
     HOST_SAFETY_DOC_TOKENS_BY_FILE,
     README_VERIFICATION_REQUIRED_TOKENS,
     RUNTIME_HYGIENE_TOKENS,
-    VERIFICATION_SUMMARY_TOKENS,
 )
 from scripts.ci.check_docs_surface import collect_docs_surface_errors
 from scripts.ci.check_discovery_surface_contract import collect_discovery_surface_errors
@@ -34,11 +36,17 @@ def _build_contributing_verification_block() -> str:
         *[f"  {test_path} \\" for test_path in BASELINE_TESTS],
         "  -q",
     ]
+    deep_realism_lines = [
+        ".venv/bin/python -m pytest \\",
+        *[f"  {test_path} \\" for test_path in DEEP_REALISM_TESTS],
+        "  -q",
+    ]
     return "\n".join(
         [
             "# Contributing",
-            *VERIFICATION_SUMMARY_TOKENS,
+            *CONTRIBUTING_VERIFICATION_REQUIRED_TOKENS,
             *baseline_lines,
+            *deep_realism_lines,
             ".venv/bin/python -m pytest tests/ -q",
         ]
     )
@@ -318,15 +326,29 @@ def test_verification_contract_passes_for_aligned_surface(tmp_path: Path) -> Non
         *[f"            {test_path} \\" for test_path in BASELINE_TESTS],
         "            -q",
     ]
+    deep_realism_lines = [
+        "          python -m pytest \\",
+        *[f"            {test_path} \\" for test_path in DEEP_REALISM_TESTS],
+        "            -q",
+    ]
     workflow_block = "\n".join(
         [
             "name: CI",
+            "on:",
+            "  workflow_dispatch:",
+            "  schedule:",
+            "    - cron: '17 8 * * *'",
             "jobs:",
             "  baseline:",
             "    steps:",
             "      - name: Baseline smoke",
             "        run: |",
             *baseline_lines,
+            f"  {DEEP_REALISM_JOB_NAME}:",
+            "    steps:",
+            "      - name: Deep realism smoke",
+            "        run: |",
+            *deep_realism_lines,
         ]
     )
     readme_text = "\n".join(
@@ -359,6 +381,44 @@ def test_verification_contract_detects_readme_drift(tmp_path: Path) -> None:
 
     errors = collect_verification_contract_errors(tmp_path)
     assert any("must not claim" in error for error in errors)
+
+
+def test_verification_contract_detects_baseline_deep_mix(tmp_path: Path) -> None:
+    mixed_baseline = "\n".join(
+        [
+            "name: CI",
+            "on:",
+            "  workflow_dispatch:",
+            "  schedule:",
+            "    - cron: '17 8 * * *'",
+            "jobs:",
+            "  baseline:",
+            "    steps:",
+            "      - name: Baseline smoke",
+            "        run: |",
+            "          notes-recovery --help",
+            "          notes-recovery demo",
+            "          python -m pytest \\",
+            *[f"            {test_path} \\" for test_path in BASELINE_TESTS],
+            *[f"            {test_path} \\" for test_path in DEEP_REALISM_TESTS],
+            "            -q",
+        ]
+    )
+    _write(
+        tmp_path / "README.md",
+        "\n".join(
+            [
+                "# NoteStore Lab",
+                *README_VERIFICATION_REQUIRED_TOKENS,
+                "[Contributing](CONTRIBUTING.md)",
+            ]
+        ),
+    )
+    _write(tmp_path / "CONTRIBUTING.md", _build_contributing_verification_block())
+    _write(tmp_path / ".github" / "workflows" / "ci.yml", mixed_baseline)
+
+    errors = collect_verification_contract_errors(tmp_path)
+    assert any("must not include deep realism test" in error for error in errors)
 
 
 def test_runtime_hygiene_tokens_track_shared_contract() -> None:


### PR DESCRIPTION
## Summary
- align NoteStore Lab public packet truth and reviewer routing with today's live surfaces
- sync ClawHub/OpenHands wording across the packet, landing/proof docs, and publish-readiness guardrails
- split deep realism tests out of the baseline PR fast lane while keeping contract/docs/tests coherent
- replay the validated change as an SSH-signed commit to satisfy required_signatures

## Validation
- `python3 scripts/release/check_skill_publish_readiness.py`
- `python3 scripts/ci/check_public_story_truth.py`
- `python3 scripts/ci/check_discovery_surface_contract.py`
- `python3 scripts/ci/check_verification_contract.py`
- `python3 -m pytest tests/test_repo_surface.py -q`
- `git diff --check`
