### PR TITLE
docs: sync forensics public lane truth

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -12,7 +12,7 @@ ecosystem without overstating what is actually shipped.
 | Claude Code | Primary | same reason as Codex, plus tracked marketplace-format metadata and a companion plugin bundle that match Claude Code's local install surface | README, `notes-recovery-mcp`, `ai-review`, `ask-case`, `.claude-plugin/marketplace.json`, `plugins/notestorelab-claude-plugin/` |
 | OpenHands | OpenHands/extensions-ready public skill folder | the repo now ships a public skill-folder packet for OpenHands/extensions while keeping runtime claims on local CLI + MCP only | `public-skills/notestorelab-case-review/`, `skills/notestorelab-case-review/`, CLI + MCP |
 | OpenCode | Secondary / comparison | the repo exposes a clean local tool / MCP story, but no dedicated OpenCode-specific integration layer | CLI + MCP are real; no OpenCode-specific contract or SDK |
-| OpenClaw | Comparison-path companion bundle | OpenClaw can consume the shipped compatible bundle archive, but this repo still does not claim a live ClawHub listing | `scripts/release/build_distribution_bundles.py`, `DISTRIBUTION.md` |
+| OpenClaw | Comparison-path companion bundle | OpenClaw can consume the shipped compatible bundle archive; the secondary ClawHub public-skill listing is live, but that still does not prove a live OpenClaw bundle listing | `scripts/release/build_distribution_bundles.py`, `DISTRIBUTION.md` |
 
 ## What Is True Today
 
@@ -39,4 +39,4 @@ ecosystem without overstating what is actually shipped.
 - no write-capable MCP by default
 - no hosted review backend
 - no generic “works with every agent framework” promise
-- no live ClawHub listing today
+- no live OpenClaw bundle listing today

--- a/llms.txt
+++ b/llms.txt
@@ -55,7 +55,7 @@
 
 - Primary fit: MCP, Codex, Claude Code
 - Secondary / comparison fit: OpenHands, OpenCode
-- OpenClaw: installable compatible bundle path exists, but there is no live ClawHub listing claim yet
+- OpenClaw: installable compatible bundle path exists; the secondary ClawHub public-skill listing is live, but that does not imply a live OpenClaw bundle listing
 - Not a primary front-door claim: hosted portals and generic agent-platform promises
 
 ## Host Notes

--- a/public-skills/README.md
+++ b/public-skills/README.md
@@ -14,8 +14,9 @@ What this pack is for:
 What this pack is not:
 
 - a dump of `.agents/skills/`
-- proof of a live listing on OpenHands/extensions, ClawHub, Glama, or Docker
-  MCP Catalog
+- proof of a live listing on OpenHands/extensions, Glama, or Docker MCP Catalog
+- proof that the live secondary ClawHub skill listing automatically means a live
+  OpenClaw bundle listing or accepted host-wrapper lane
 - a hosted runtime or remote MCP deployment
 
 Current public-safe contents:
@@ -23,6 +24,7 @@ Current public-safe contents:
 - `notestorelab-case-review/`
   - OpenHands/extensions-friendly public skill folder
   - ClawHub-style manifest with semver-ready listing metadata
+  - today the secondary ClawHub public-skill listing is already live
   - one derived copy of the canonical `skills/notestorelab-case-review/SKILL.md`
 
 Public-safe inclusion test:

--- a/scripts/release/check_skill_publish_readiness.py
+++ b/scripts/release/check_skill_publish_readiness.py
@@ -136,6 +136,7 @@ def collect_skill_publish_errors(repo_root: Path) -> list[str]:
     public_skill_manifest = public_skill_dir / "manifest.yaml"
     public_skill_readme = public_skill_dir / "README.md"
     public_skill_demo = repo_root / PUBLIC_SKILL_DEMO_PATH
+    public_skill_root_readme = repo_root / "public-skills" / "README.md"
     if not public_skill_dir.exists():
         errors.append(f"missing public skill directory: {PUBLIC_SKILL_DIR}")
     if not public_skill_manifest.exists():
@@ -144,6 +145,8 @@ def collect_skill_publish_errors(repo_root: Path) -> list[str]:
         errors.append(f"missing public skill README: {public_skill_readme.relative_to(repo_root)}")
     if not public_skill_demo.exists():
         errors.append(f"missing public skill demo reference: {public_skill_demo.relative_to(repo_root)}")
+    if not public_skill_root_readme.exists():
+        errors.append("missing public-skills/README.md")
     if public_skill_manifest.exists():
         public_manifest_text = public_skill_manifest.read_text(encoding="utf-8")
         for token in (
@@ -214,6 +217,21 @@ def collect_skill_publish_errors(repo_root: Path) -> list[str]:
             errors.append(
                 "public skill demo reference still points first-hop proof at a blob page"
             )
+    if public_skill_root_readme.exists():
+        public_skill_root_text = public_skill_root_readme.read_text(encoding="utf-8")
+        for token in (
+            "OpenHands/extensions-friendly public skill folder",
+            "ClawHub-style manifest with semver-ready listing metadata",
+            "today the secondary ClawHub public-skill listing is already live",
+        ):
+            if token not in public_skill_root_text:
+                errors.append(f"public-skills/README.md is missing required token: {token}")
+        for token in (
+            "proof of a live listing on OpenHands/extensions, ClawHub, Glama, or Docker",
+            "no live ClawHub listing today",
+        ):
+            if token in public_skill_root_text:
+                errors.append(f"public-skills/README.md still contains stale listing wording: {token}")
     for legacy_ref in LEGACY_PUBLIC_REFERENCE_FILES:
         if (repo_root / legacy_ref).exists():
             errors.append(f"legacy public skill reference should be removed: {legacy_ref}")
@@ -274,12 +292,16 @@ def collect_skill_publish_errors(repo_root: Path) -> list[str]:
         ("README.md", readme_text),
         ("DISTRIBUTION.md", distribution_text),
         ("INTEGRATIONS.md", integrations_text),
+        ("llms.txt", llms_text),
+        ("ECOSYSTEM.md", ecosystem_text),
     ):
         for token in (
             "no live ClawHub/OpenHands/extensions/Glama/Docker catalog listing language in Wave 1",
             "do not claim live ClawHub or official OpenClaw listing",
             "Treat ClawHub publication as a later manual external step",
             "do not claim a live ClawHub listing yet",
+            "there is no live ClawHub listing claim yet",
+            "no live ClawHub listing today",
         ):
             if token in text:
                 errors.append(f"{rel_path} still contains stale ClawHub or OpenHands wording: {token}")


### PR DESCRIPTION
## Summary
- sync stale ClawHub under-claims in llms/ecosystem/public-skill index surfaces
- keep public-distribution language aligned with today's live secondary packet lane
- extend publish-readiness guardrails so those stale phrases do not drift back

## Validation
- `python3 scripts/release/check_skill_publish_readiness.py`
- `python3 scripts/ci/check_public_story_truth.py`
- `python3 scripts/ci/check_discovery_surface_contract.py`
- `python3 scripts/ci/check_verification_contract.py`
- `python3 -m pytest tests/test_repo_surface.py -q`
- `git diff --check`
